### PR TITLE
Use Task.Factory.StartNew() instead of Task.Start(). #89

### DIFF
--- a/libraries/ZigBeeNet.Transport.SerialPort/ZigBeeSerialPort.cs
+++ b/libraries/ZigBeeNet.Transport.SerialPort/ZigBeeSerialPort.cs
@@ -97,9 +97,7 @@ namespace ZigBeeNet.Tranport.SerialPort
             if (_serialPort.IsOpen)
             {
                 // Start Reader Task
-                _reader = new Task(ReaderTask, _cancellationToken.Token);
-
-                _reader.Start();
+                Task.Factory.StartNew(ReaderTask, _cancellationToken.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
 
                 // TODO: ConnectionStatusChanged event
             }
@@ -172,7 +170,7 @@ namespace ZigBeeNet.Tranport.SerialPort
         {
             var message = new byte[512];
 
-            while (IsOpen && _cancellationToken.IsCancellationRequested == false)
+            while (IsOpen && !_cancellationToken.IsCancellationRequested)
             {
                 try
                 {
@@ -186,8 +184,11 @@ namespace ZigBeeNet.Tranport.SerialPort
                 }
                 catch (Exception e)
                 {
-                    Log.Error(e, "Error while reading from serial port");
-                    Thread.Sleep(1000);
+                    if (!_cancellationToken.IsCancellationRequested)
+                    {
+                        Log.Error(e, "Error while reading from serial port");
+                        Thread.Sleep(1000);
+                    }
                 }
             }
         }

--- a/libraries/ZigBeeNet/Database/ZigBeeNetworkDatabaseManager.cs
+++ b/libraries/ZigBeeNet/Database/ZigBeeNetworkDatabaseManager.cs
@@ -160,8 +160,7 @@ namespace ZigBeeNet.Database
 
             //The consumer task that process the nodes produced by the elapsed timers
             //This ensure all write are done using a single thread.
-            Task writerTask = new Task(WriteNodeLoop, TaskCreationOptions.LongRunning);
-            writerTask.Start();
+            Task.Factory.StartNew(WriteNodeLoop, TaskCreationOptions.LongRunning);
 
             _networkManager.AddNetworkNodeListener(this);
         }

--- a/libraries/ZigBeeNet/ZigBeeEndpoint.cs
+++ b/libraries/ZigBeeNet/ZigBeeEndpoint.cs
@@ -448,10 +448,10 @@ namespace ZigBeeNet
          /// <param name="responseMatcher">the <see cref="ZigBeeTransactionMatcher"> used to match the response to the request</param>
          /// <returns>the <see cref="CommandResult"> future.</returns>
          /// </summary>
-        public async Task<CommandResult> SendTransaction(ZigBeeCommand command, IZigBeeTransactionMatcher responseMatcher)
+        public Task<CommandResult> SendTransaction(ZigBeeCommand command, IZigBeeTransactionMatcher responseMatcher)
         {
             command.DestinationAddress = GetEndpointAddress();
-            return await Node.SendTransaction(command, responseMatcher);
+            return Node.SendTransaction(command, responseMatcher);
         }
 
         public override string ToString()

--- a/libraries/ZigBeeNet/ZigBeeNetworkManager.cs
+++ b/libraries/ZigBeeNet/ZigBeeNetworkManager.cs
@@ -1012,17 +1012,17 @@ namespace ZigBeeNet
         /// <param name="command">the <see cref="ZclCommand"/></param>
         /// <returns>the command result future</returns>
         /// </summary>
-        public async Task<CommandResult> Send(IZigBeeAddress destination, ZclCommand command)
+        public Task<CommandResult> Send(IZigBeeAddress destination, ZclCommand command)
         {
             command.DestinationAddress = destination;
             if (destination.IsGroup)
             {
-                return await Broadcast(command);
+                return Broadcast(command);
             }
             else
             {
                 IZigBeeTransactionMatcher responseMatcher = new ZclTransactionMatcher();
-                return await SendTransaction(command, responseMatcher);
+                return SendTransaction(command, responseMatcher);
             }
         }
 
@@ -1532,10 +1532,10 @@ namespace ZigBeeNet
             SendCommand(command);
         }
 
-        public async Task<CommandResult> SendTransaction(ZigBeeCommand command, IZigBeeTransactionMatcher responseMatcher)
+        public Task<CommandResult> SendTransaction(ZigBeeCommand command, IZigBeeTransactionMatcher responseMatcher)
         {
             ZigBeeTransaction transaction = new ZigBeeTransaction(this);
-            return await transaction.SendTransaction(command, responseMatcher);
+            return transaction.SendTransaction(command, responseMatcher);
         }
     }
 }

--- a/libraries/ZigBeeNet/ZigBeeNode.cs
+++ b/libraries/ZigBeeNet/ZigBeeNode.cs
@@ -643,9 +643,9 @@ namespace ZigBeeNet
             _network.SendTransaction(command);
         }
 
-        public async Task<CommandResult> SendTransaction(ZigBeeCommand command, IZigBeeTransactionMatcher responseMatcher)
+        public Task<CommandResult> SendTransaction(ZigBeeCommand command, IZigBeeTransactionMatcher responseMatcher)
         {
-            return await _network.SendTransaction(command, responseMatcher);
+            return _network.SendTransaction(command, responseMatcher);
         }
 
         public override string ToString()


### PR DESCRIPTION
Avoid return await. #81
Avoid logging exception in ZigBeeSerialPort.ReaderTask() when network is shut down.