### PR TITLE
Fix various initialization problem for XBee and Ember dongles

### DIFF
--- a/libraries/ZigBeeNet.Hardware.Digi.XBee/Internal/XBeeFrameHandler.cs
+++ b/libraries/ZigBeeNet.Hardware.Digi.XBee/Internal/XBeeFrameHandler.cs
@@ -313,9 +313,9 @@ namespace ZigBeeNet.Hardware.Digi.XBee.Internal
             // Remember the command we're processing
             _sentCommand = nextFrame;
 
-            _serialPort.Write(new byte[] { XBEE_FLAG });
-
             // Send the data
+            List<byte> bytes = new List<byte>();
+            bytes.Add(XBEE_FLAG);
             StringBuilder builder = new StringBuilder();
             int[] frames = nextFrame.Serialize();
             foreach (int sendByte in frames)
@@ -323,15 +323,16 @@ namespace ZigBeeNet.Hardware.Digi.XBee.Internal
                 builder.Append(string.Format(" 0x{0:X2}", sendByte));
                 if (_escapeCodes.Contains((byte)sendByte))
                 {
-                    _serialPort.Write(new byte[] { XBEE_ESCAPE });
-                    _serialPort.Write(new byte[] { (byte)(sendByte ^ XBEE_XOR) });
+                    bytes.Add(XBEE_ESCAPE);
+                    bytes.Add((byte)(sendByte ^ XBEE_XOR));
                 }
                 else
                 {
-                    _serialPort.Write(new byte[] { (byte)sendByte });
+                    bytes.Add((byte)sendByte);
                 }
             }
             Log.Verbose($"TX XBEE Data:{builder.ToString()}");
+            _serialPort.Write(bytes.ToArray());
 
             // Start the timeout
             Log.Verbose("XBEE Timer: Start");

--- a/libraries/ZigBeeNet.Hardware.Digi.XBee/ZigBeeDongleXBee.cs
+++ b/libraries/ZigBeeNet.Hardware.Digi.XBee/ZigBeeDongleXBee.cs
@@ -18,8 +18,6 @@ namespace ZigBeeNet.Hardware.Digi.XBee
         private readonly IZigBeePort _serialPort;
         private IXBeeFrameHandler _frameHandler;
         private IZigBeeTransportReceive _zigBeeTransportReceive;
-        private readonly ZigBeeChannel _radioChannel;
-        private readonly ExtendedPanId _extendedPanId;
         private bool _coordinatorStarted;
         private bool _initialisationComplete;
 
@@ -44,8 +42,8 @@ namespace ZigBeeNet.Hardware.Digi.XBee
         public string VersionString { get; set; } = "Unknown";
         public IeeeAddress IeeeAddress { get; set; }
         public ushort NwkAddress { get; set; }
-        public ZigBeeKey LinkKey { get; private set; } = new ZigBeeKey(new byte[] { 0x5A, 0x69, 0x67, 0x42, 0x65, 0x65, 0x41, 0x6C, 0x6C, 0x69, 0x61, 0x6E, 0x63, 0x65, 0x30, 0x39 });
-        public ZigBeeKey NetworkKey { get; private set; } = new ZigBeeKey();
+        public ZigBeeKey TcLinkKey { get; private set; } = new ZigBeeKey(new byte[] { 0x5A, 0x69, 0x67, 0x42, 0x65, 0x65, 0x41, 0x6C, 0x6C, 0x69, 0x61, 0x6E, 0x63, 0x65, 0x30, 0x39 });
+        public ZigBeeKey ZigBeeNetworkKey { get; private set; } = new ZigBeeKey();
 
         public ZigBeeChannel ZigBeeChannel
         {
@@ -58,17 +56,13 @@ namespace ZigBeeNet.Hardware.Digi.XBee
                 XBeeGetOperatingChannelCommand request = new XBeeGetOperatingChannelCommand();
                 XBeeOperatingChannelResponse response = (XBeeOperatingChannelResponse)_frameHandler.SendRequest(request);
 
-                return (ZigBeeChannel)response.GetChannel();
+                return (ZigBeeChannel)(1 << response.GetChannel());
             }
         }
 
         public ushort PanID { get; private set; }
 
         public ExtendedPanId ExtendedPanId { get; private set; }
-
-        public ZigBeeKey ZigBeeNetworkKey { get; private set; }
-
-        public ZigBeeKey TcLinkKey { get; private set; }
 
         #endregion properties
 
@@ -174,12 +168,12 @@ namespace ZigBeeNet.Hardware.Digi.XBee
 
             // Set the network key
             XBeeSetNetworkKeyCommand networkKey = new XBeeSetNetworkKeyCommand();
-            networkKey.SetNetworkKey(new ZigBeeKey());
+            networkKey.SetNetworkKey(ZigBeeNetworkKey);
             _frameHandler.SendRequest(networkKey);
 
             // Set the link key
             XBeeSetLinkKeyCommand setLinkKey = new XBeeSetLinkKeyCommand();
-            setLinkKey.SetLinkKey(LinkKey);
+            setLinkKey.SetLinkKey(TcLinkKey);
             _frameHandler.SendRequest(setLinkKey);
 
             // Save the configuration in the XBee
@@ -376,13 +370,13 @@ namespace ZigBeeNet.Hardware.Digi.XBee
 
         public ZigBeeStatus SetZigBeeNetworkKey(ZigBeeKey key)
         {
-            NetworkKey = key;
+            ZigBeeNetworkKey = key;
             return ZigBeeStatus.SUCCESS;
         }
 
         public ZigBeeStatus SetTcLinkKey(ZigBeeKey key)
         {
-            LinkKey = key;
+            TcLinkKey = key;
             return ZigBeeStatus.SUCCESS;
         }
 

--- a/libraries/ZigBeeNet.Transport.SerialPort/ZigBeeSerialPort.cs
+++ b/libraries/ZigBeeNet.Transport.SerialPort/ZigBeeSerialPort.cs
@@ -76,6 +76,7 @@ namespace ZigBeeNet.Tranport.SerialPort
                 Log.Debug("Opening port {Port} at {Baudrate} baud with {FlowControl}", PortName, Baudrate, FlowControl);
 
                 _serialPort = new System.IO.Ports.SerialPort(PortName, baudrate);
+                _serialPort.WriteTimeout = 3000;
                 //_serialPort.Handshake = System.IO.Ports.Handshake.XOnXOff;
 
                 try
@@ -89,26 +90,24 @@ namespace ZigBeeNet.Tranport.SerialPort
                     if (tryOpen)
                     {
                         _serialPort.Open();
-
-                        success = true;
                     }
                 }
                 catch (Exception ex)
                 {
-                    Log.Debug("{Exception} - Error opening port {Port}\n{Port}", ex.GetType().Name, PortName, ex.Message);
+                    Log.Debug("Error opening port {Port}: {Exception}", PortName, ex.Message);
                 }
 
                 if (_serialPort.IsOpen)
                 {
                     // Start Reader Task
                     _reader = Task.Factory.StartNew(ReaderTask, _cancellationToken.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
-
+                    success = true;
                     // TODO: ConnectionStatusChanged event
                 }
             }
             catch (Exception e)
             {
-                Log.Warning("Unable to open serial port: " + e.Message);
+                Log.Warning("Unable to open serial port: {Exception}", e.Message);
             }
 
             return success;
@@ -150,7 +149,7 @@ namespace ZigBeeNet.Tranport.SerialPort
             }
             catch (Exception e)
             {
-                Log.Error(e, "Error while reading byte from serial port: {Exception}");
+                Log.Error(e, "Error while reading byte from serial port: {Exception}", e.Message);
             }
             return null;
         }
@@ -170,7 +169,7 @@ namespace ZigBeeNet.Tranport.SerialPort
                 }
                 catch (Exception e)
                 {
-                    Log.Error(e, "Error while writing to serial port: {Exception}");
+                    Log.Error(e, "Error while writing to serial port: {Exception}", e.Message);
                 }
             }
         }
@@ -195,7 +194,7 @@ namespace ZigBeeNet.Tranport.SerialPort
                 {
                     if (!_cancellationToken.IsCancellationRequested)
                     {
-                        Log.Error(e, "Error while reading from serial port: {Exception}");
+                        Log.Error(e, "Error while reading from serial port: {Exception}", e.Message);
                         Thread.Sleep(1000);
                     }
                 }

--- a/libraries/ZigBeeNet/ZigBeeNetworkManager.cs
+++ b/libraries/ZigBeeNet/ZigBeeNetworkManager.cs
@@ -467,8 +467,9 @@ namespace ZigBeeNet
             Log.Debug("ZigBeeNetworkManager startup: reinitialize={Reinitialize}, networkState={NetworkState}", reinitialize, NetworkState);
             lock (_networkStateSync)
             {
-                if (NetworkState == ZigBeeNetworkState.UNINITIALISED)
+                if (NetworkState != ZigBeeNetworkState.INITIALISING)
                 {
+                    Log.Error("ZigBeeNetworkManager startup: Can't be called when NetworkState={NetworkState}", NetworkState);
                     return ZigBeeStatus.INVALID_STATE;
                 }
             }

--- a/libraries/ZigbeeNet.Hardware.Ember/Internal/Ash/AshFrameHandler.cs
+++ b/libraries/ZigbeeNet.Hardware.Ember/Internal/Ash/AshFrameHandler.cs
@@ -472,10 +472,13 @@ namespace ZigBeeNet.Hardware.Ember.Internal.Ash
             Log.Debug("--> TX ASH frame: {Frame}", ashFrame);
 
             // Send the data
-            foreach (int outByte in ashFrame.GetOutputBuffer()) 
+            int[] data = ashFrame.GetOutputBuffer();
+            byte[] bytes = new byte[data.Length];
+            for(int i = 0; i < data.Length; i++) 
             {
-                _port.Write(new byte[] { (byte)outByte });
+                bytes[i] = (byte)data[i];
             }
+            _port.Write(bytes);
 
             // Only start the timer for data and reset frames
             if (ashFrame is AshFrameData || ashFrame is AshFrameRst) 
@@ -599,15 +602,7 @@ namespace ZigBeeNet.Hardware.Ember.Internal.Ash
                 if (_stateConnected && _sentQueue.IsEmpty)
                     return;
 
-                // If we're not connected, then try again
-                if (!_stateConnected) 
-                {
-                    StopTimer();
-                    Reconnect();
-                    return;
-                }
-
-                if (_retries++ > ACK_TIMEOUTS) 
+                if (++_retries > ACK_TIMEOUTS) 
                 {
                     Log.Debug("ASH: Error number of retries exceeded [{Retries}].", _retries);
 
@@ -620,7 +615,8 @@ namespace ZigBeeNet.Hardware.Ember.Internal.Ash
                 // If we're not connected, then try the reset again
                 if (!_stateConnected) 
                 {
-                    SendFrame(new AshFrameRst());
+                    StopTimer();
+                    Reconnect();
                     return;
                 }
 

--- a/libraries/ZigbeeNet.Hardware.Ember/ZigBeeDongleEzsp.cs
+++ b/libraries/ZigbeeNet.Hardware.Ember/ZigBeeDongleEzsp.cs
@@ -951,7 +951,7 @@ namespace ZigBeeNet.Hardware.Ember
 
         public ZigBeeChannel ZigBeeChannel
         {
-            get { return (ZigBeeChannel)_networkParameters.GetRadioChannel(); } 
+            get { return (ZigBeeChannel)(1 << _networkParameters.GetRadioChannel()); } 
         }
 
         public ZigBeeStatus SetZigBeeChannel(ZigBeeChannel channel) 


### PR DESCRIPTION
For example I added a 3 seconds timeout for serial port writes, because otherwise if you try to initialize a network using a wrong serial port by mistake the program is stuck on the first write indefinitely.