### PR TITLE
Fix compilation warnings

### DIFF
--- a/autocode/ZigBeeNet.Digi.XBee.CodeGenerator/ClassGenerator.cs
+++ b/autocode/ZigBeeNet.Digi.XBee.CodeGenerator/ClassGenerator.cs
@@ -11,7 +11,7 @@ namespace ZigBeeNet.Digi.XBee.CodeGenerator
     public abstract class ClassGenerator
     {
         readonly int _lineLen = 80;
-        readonly string _sourceRootPath = "ZigBeeNet.Libraries.ZigBeeNet.Hardware.Digi.XBee";
+        //readonly string _sourceRootPath = "ZigBeeNet.Libraries.ZigBeeNet.Hardware.Digi.XBee";
         readonly List<string> _importList = new List<string>();
 
         protected StringBuilder GetClassOut(FileInfo packageFile, string className)

--- a/libraries/ZigBeeNet.Hardware.Digi.XBee/ZigBeeDongleXBee.cs
+++ b/libraries/ZigBeeNet.Hardware.Digi.XBee/ZigBeeDongleXBee.cs
@@ -402,7 +402,7 @@ namespace ZigBeeNet.Hardware.Digi.XBee
                             break;
                     }
                 }
-                catch (InvalidCastException e)
+                catch (InvalidCastException)
                 {
                     configuration.SetResult(option, ZigBeeStatus.INVALID_ARGUMENTS);
                 }

--- a/libraries/ZigBeeNet.Hardware.TI.CC2531/Frame/ZdoIeeeAddress.cs
+++ b/libraries/ZigBeeNet.Hardware.TI.CC2531/Frame/ZdoIeeeAddress.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Text;
 using ZigBeeNet.Hardware.TI.CC2531.Packet;
 using ZigBeeNet.ZDO;
-using System.Linq;
 
 namespace ZigBeeNet.Hardware.TI.CC2531.Frame
 {

--- a/libraries/ZigBeeNet.Hardware.TI.CC2531/Implementation/CommandInterfaceImpl.cs
+++ b/libraries/ZigBeeNet.Hardware.TI.CC2531/Implementation/CommandInterfaceImpl.cs
@@ -219,7 +219,7 @@ namespace ZigBeeNet.Hardware.TI.CC2531.Implementation
                             _commandListenerSync.Wait(500);
                             CleanExpiredSynchronousCommandListeners();
                         }
-                        catch (Exception ignored)
+                        catch (Exception)
                         {
                         }
                     }
@@ -239,7 +239,7 @@ namespace ZigBeeNet.Hardware.TI.CC2531.Implementation
                             _commandListenerSync.Wait(500);
                             CleanExpiredSynchronousCommandListeners();
                         }
-                        catch (Exception ignored)
+                        catch (Exception)
                         {
                         }
                     }

--- a/libraries/ZigBeeNet.Hardware.TI.CC2531/Network/NetworkManager.cs
+++ b/libraries/ZigBeeNet.Hardware.TI.CC2531/Network/NetworkManager.cs
@@ -77,12 +77,14 @@ namespace ZigBeeNet.Hardware.TI.CC2531.Network
 
         private static ManualResetEventSlim _hardwareSync = new ManualResetEventSlim(false);
 
+#pragma warning disable CS0649
         private byte[] _ep;
         private byte[] _prof;
         private byte[] _dev;
         private byte[] _ver;
         private ushort[][] _inp;
         private ushort[][] _out;
+#pragma warning restore CS0649
 
         private NetworkStateListener _announceListenerFilter = new NetworkStateListener();
 
@@ -439,7 +441,7 @@ namespace ZigBeeNet.Hardware.TI.CC2531.Network
                     {
                         _hardwareSync.Wait();
                     }
-                    catch (Exception ignored)
+                    catch (Exception)
                     {
                     }
                 }
@@ -469,7 +471,7 @@ namespace ZigBeeNet.Hardware.TI.CC2531.Network
                             timedOut = true;
                         }
                     }
-                    catch (Exception ignored)
+                    catch (Exception)
                     {
                     }
 

--- a/libraries/ZigBeeNet.Hardware.TI.CC2531/Packet/ZToolPacket.cs
+++ b/libraries/ZigBeeNet.Hardware.TI.CC2531/Packet/ZToolPacket.cs
@@ -179,12 +179,9 @@ namespace ZigBeeNet.Hardware.TI.CC2531.Packet
             }
         }
 
-        public ushort CommandId
+        public ushort GetCommandId()
         {
-            get
-            {
-                return ByteHelper.ShortFromBytes(Packet, 2, 3);
-            }
+            return ByteHelper.ShortFromBytes(Packet, 2, 3);
         }
 
         public override string ToString()

--- a/libraries/ZigBeeNet.Hardware.TI.CC2531/Packet/ZToolParseException.cs
+++ b/libraries/ZigBeeNet.Hardware.TI.CC2531/Packet/ZToolParseException.cs
@@ -6,7 +6,7 @@ namespace ZigBeeNet.Hardware.TI.CC2531.Packet
 {
     public class ZToolParseException : Exception
     {
-        private static long serialVersionUID = 6752060371295132748L;
+        //private static long serialVersionUID = 6752060371295132748L;
 
         public ZToolParseException(string s)
             : base(s)

--- a/libraries/ZigBeeNet.Hardware.TI.CC2531/Util/ZToolAddress16.cs
+++ b/libraries/ZigBeeNet.Hardware.TI.CC2531/Util/ZToolAddress16.cs
@@ -91,7 +91,7 @@ namespace ZigBeeNet.Hardware.TI.CC2531.Util
 
                     return (this.Lsb == addr.Lsb && this.Msb == addr.Msb);
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                     return false;
                 }

--- a/libraries/ZigBeeNet/App/Discovery/ZigBeeDiscoveryExtension.cs
+++ b/libraries/ZigBeeNet/App/Discovery/ZigBeeDiscoveryExtension.cs
@@ -237,7 +237,7 @@ namespace ZigBeeNet.App.Discovery
                 ZigBeeNodeServiceDiscoverer nodeDiscoverer = new ZigBeeNodeServiceDiscoverer(_networkManager, node);
                 nodeDiscoverer.MeshUpdateTasks = MeshUpdateTasks;
                 _nodeDiscovery[node.IeeeAddress] = nodeDiscoverer;
-                nodeDiscoverer.StartDiscovery();
+                _ = nodeDiscoverer.StartDiscovery();
             }
         }
 

--- a/libraries/ZigBeeNet/Serialization/DefaultDeserializer.cs
+++ b/libraries/ZigBeeNet/Serialization/DefaultDeserializer.cs
@@ -97,7 +97,7 @@ namespace ZigBeeNet.Serialization
 
                         value[0] = Encoding.Default.GetString(dest);
                     }
-                    catch (Exception e)
+                    catch (Exception)
                     {
                         value[0] = null;
                         break;

--- a/libraries/ZigBeeNet/ZigBeeGroupAddress.cs
+++ b/libraries/ZigBeeNet/ZigBeeGroupAddress.cs
@@ -58,7 +58,7 @@ namespace ZigBeeNet
         public ZigBeeGroupAddress(ushort groupId, string label)
         {
             GroupId = groupId;
-            Label = Label;
+            Label = label;
         }
 
         public bool IsGroup

--- a/test/ZigBeeNet.Hardware.Digi.XBee.Test/Internal/XBeeFrameHandlerTest.cs
+++ b/test/ZigBeeNet.Hardware.Digi.XBee.Test/Internal/XBeeFrameHandlerTest.cs
@@ -134,7 +134,7 @@ namespace ZigBeeNet.Hardware.Digi.XBee.Test
             {
                 return Convert.ToByte(_memoryStream.ReadByte());
             }
-            catch (IOException ex)
+            catch (IOException)
             {
                 return null;
             }

--- a/test/ZigBeeNet.Hardware.TI.CC2531.Test/Cc2351TestPacket.cs
+++ b/test/ZigBeeNet.Hardware.TI.CC2531.Test/Cc2351TestPacket.cs
@@ -41,7 +41,7 @@ namespace ZigBeeNet.Hardware.TI.CC2531.Test
 
                 return ztoolPacket;
             }
-            catch (IOException e)
+            catch (IOException)
             {
                 return null;
             }

--- a/test/ZigBeeNet.Hardware.TI.CC2531.Test/TestPort.cs
+++ b/test/ZigBeeNet.Hardware.TI.CC2531.Test/TestPort.cs
@@ -41,7 +41,7 @@ namespace ZigBeeNet.Hardware.TI.CC2531.Test
             {
                 return (byte)input.ReadByte();
             }
-            catch (IOException e)
+            catch (IOException)
             {
                 return null;
             }


### PR DESCRIPTION
I fixed most of compilation warnings. 
The one remainings are the following kind:

`warning NU5048: The 'PackageIconUrl'/'iconUrl' element is deprecated. Consider using the 'PackageIcon'/'icon' element instead. Learn more at https://aka.ms/deprecateIconUrl`

@Mr-Markus  Do you see those and can you fix them?
