### PR TITLE
ZclDataType refactor

### DIFF
--- a/libraries/ZigBeeNet/ZCL/Protocol/ZclDataType.cs
+++ b/libraries/ZigBeeNet/ZCL/Protocol/ZclDataType.cs
@@ -73,7 +73,7 @@ namespace ZigBeeNet.ZCL.Protocol
             _codeTypeMapping[0x2F] = new ZclDataType("Signed 64-bit Integer", typeof(long), 0x2F, true, DataType.SIGNED_64_BIT_INTEGER);
             _codeTypeMapping[0x30] = new ZclDataType("8-bit Enumeration", typeof(byte), 0x30, false, DataType.ENUMERATION_8_BIT);
             _codeTypeMapping[0x31] = new ZclDataType("16-bit Enumeration", typeof(ushort), 0x31, false, DataType.ENUMERATION_16_BIT);
-            _codeTypeMapping[0x32] = new ZclDataType("32-bit Enumeration", typeof(uint), 0x32, false, DataType.ENUMERATION_32_BIT);
+            _codeTypeMapping[0x33] = new ZclDataType("32-bit Enumeration", typeof(uint), 0x33, false, DataType.ENUMERATION_32_BIT);
             _codeTypeMapping[0x38] = new ZclDataType("Semi precision float", typeof(float), 0x38, true, DataType.FLOAT_16_BIT);
             _codeTypeMapping[0x39] = new ZclDataType("Single precision float", typeof(float), 0x39, true, DataType.FLOAT_32_BIT);
             _codeTypeMapping[0x3A] = new ZclDataType("Double precision float", typeof(double), 0x3A, true, DataType.FLOAT_64_BIT);
@@ -139,7 +139,7 @@ namespace ZigBeeNet.ZCL.Protocol
 
         public static ZclDataType Get(DataType type)
         {
-            return _codeTypeMapping.Values.Single(dt => dt.DataType == type);
+            return _codeTypeMapping[(int)type];
         }
 
         public override string ToString()

--- a/libraries/ZigBeeNet/ZCL/Protocol/ZclDataType.cs
+++ b/libraries/ZigBeeNet/ZCL/Protocol/ZclDataType.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using ZigBeeNet.Security;
 using ZigBeeNet.ZCL.Field;
 using ZigBeeNet.ZDO;
@@ -11,12 +9,12 @@ namespace ZigBeeNet.ZCL.Protocol
 {
     public class ZclDataType
     {
-        private static Dictionary<int, ZclDataType> _codeTypeMapping;
+        private static ZclDataType[] _codeTypeMapping;
 
         internal Type DataClass { get; set; }
 
         public string Label { get; set; }
-        public int Id { get; set; }
+        public byte Id { get; set; }
         public bool IsAnalog { get; set; }
         public DataType DataType { get; set; }
 
@@ -25,7 +23,7 @@ namespace ZigBeeNet.ZCL.Protocol
 
         }
 
-        private ZclDataType(string label, Type dataClass, int id, bool analogue, DataType dataType)
+        private ZclDataType(string label, Type dataClass, byte id, bool analogue, DataType dataType)
         {
             this.Label = label;
             this.DataClass = dataClass;
@@ -36,112 +34,113 @@ namespace ZigBeeNet.ZCL.Protocol
 
         static ZclDataType()
         {
-            _codeTypeMapping = new Dictionary<int, ZclDataType>();
+            _codeTypeMapping = new ZclDataType[256];
+            void Add(ZclDataType zclDataType) => _codeTypeMapping[(byte)zclDataType.DataType]=zclDataType;
 
-            _codeTypeMapping[0x08] = new ZclDataType("8-bit data", typeof(byte), 0x08, false, DataType.DATA_8_BIT);
-            _codeTypeMapping[0x09] = new ZclDataType("16-bit data", null, 0x09, false, DataType.DATA_16_BIT);
-            _codeTypeMapping[0x0A] = new ZclDataType("24-bit data", null, 0x0A, false, DataType.DATA_24_BIT);
-            _codeTypeMapping[0x0B] = new ZclDataType("32-bit data", null, 0x0B, false, DataType.DATA_32_BIT);
-            _codeTypeMapping[0x0C] = new ZclDataType("40-bit data", null, 0x0C, false, DataType.DATA_40_BIT);
-            _codeTypeMapping[0x0D] = new ZclDataType("48-bit data", null, 0x0D, false, DataType.DATA_48_BIT);
-            _codeTypeMapping[0x0E] = new ZclDataType("56-bit data", null, 0x0E, false, DataType.DATA_56_BIT);
-            _codeTypeMapping[0x0F] = new ZclDataType("64-bit data", null, 0x0F, false, DataType.DATA_64_BIT);
-            _codeTypeMapping[0x10] = new ZclDataType("Boolean", typeof(bool), 0x10, false, DataType.BOOLEAN);
-            _codeTypeMapping[0x18] = new ZclDataType("8-bit Bitmap", typeof(byte), 0x18, false, DataType.BITMAP_8_BIT);
-            _codeTypeMapping[0x19] = new ZclDataType("16-bit Bitmap", typeof(ushort), 0x19, false, DataType.BITMAP_16_BIT);
-            _codeTypeMapping[0x1A] = new ZclDataType("24-bit Bitmap", typeof(uint), 0x1A, false, DataType.BITMAP_24_BIT);
-            _codeTypeMapping[0x1B] = new ZclDataType("32-bit Bitmap", typeof(uint), 0x1B, false, DataType.BITMAP_32_BIT);
-            _codeTypeMapping[0x1C] = new ZclDataType("40-bit Bitmap", typeof(ulong), 0x1C, false, DataType.BITMAP_40_BIT);
-            _codeTypeMapping[0x1D] = new ZclDataType("48-bit Bitmap", typeof(ulong), 0x1D, false, DataType.BITMAP_48_BIT);
-            _codeTypeMapping[0x1E] = new ZclDataType("56-bit Bitmap", typeof(ulong), 0x1E, false, DataType.BITMAP_56_BIT);
-            _codeTypeMapping[0x1F] = new ZclDataType("64-bit Bitmap", typeof(ulong), 0x1F, false, DataType.BITMAP_64_BIT);
-            _codeTypeMapping[0x20] = new ZclDataType("Unsigned 8-bit integer", typeof(byte), 0x20, true, DataType.UNSIGNED_8_BIT_INTEGER);
-            _codeTypeMapping[0x21] = new ZclDataType("Unsigned 16-bit integer", typeof(ushort), 0x21, true, DataType.UNSIGNED_16_BIT_INTEGER);
-            _codeTypeMapping[0x22] = new ZclDataType("Unsigned 24-bit integer", typeof(uint), 0x22, true, DataType.UNSIGNED_24_BIT_INTEGER);
-            _codeTypeMapping[0x23] = new ZclDataType("Unsigned 32-bit integer", typeof(uint), 0x23, true, DataType.UNSIGNED_32_BIT_INTEGER);
-            _codeTypeMapping[0x24] = new ZclDataType("Unsigned 40-bit integer", typeof(ulong), 0x24, true, DataType.UNSIGNED_40_BIT_INTEGER);
-            _codeTypeMapping[0x25] = new ZclDataType("Unsigned 48-bit integer", typeof(ulong), 0x25, true, DataType.UNSIGNED_48_BIT_INTEGER);
-            _codeTypeMapping[0x26] = new ZclDataType("Unsigned 56-bit integer", typeof(ulong), 0x26, true, DataType.UNSIGNED_56_BIT_INTEGER);
-            _codeTypeMapping[0x27] = new ZclDataType("Unsigned 64-bit integer", typeof(ulong), 0x27, true, DataType.UNSIGNED_64_BIT_INTEGER);
-            _codeTypeMapping[0x28] = new ZclDataType("Signed 8-bit Integer", typeof(sbyte), 0x28, true, DataType.SIGNED_8_BIT_INTEGER);
-            _codeTypeMapping[0x29] = new ZclDataType("Signed 16-bit Integer", typeof(short), 0x29, true, DataType.SIGNED_16_BIT_INTEGER);
-            _codeTypeMapping[0x2A] = new ZclDataType("Signed 24-bit Integer", typeof(int), 0x2A, true, DataType.SIGNED_24_BIT_INTEGER);
-            _codeTypeMapping[0x2B] = new ZclDataType("Signed 32-bit Integer", typeof(int), 0x2B, true, DataType.SIGNED_32_BIT_INTEGER);
-            _codeTypeMapping[0x2C] = new ZclDataType("Signed 40-bit Integer", typeof(long), 0x2C, true, DataType.SIGNED_40_BIT_INTEGER);
-            _codeTypeMapping[0x2D] = new ZclDataType("Signed 48-bit Integer", typeof(long), 0x2D, true, DataType.SIGNED_48_BIT_INTEGER);
-            _codeTypeMapping[0x2E] = new ZclDataType("Signed 56-bit Integer", typeof(long), 0x2E, true, DataType.SIGNED_56_BIT_INTEGER);
-            _codeTypeMapping[0x2F] = new ZclDataType("Signed 64-bit Integer", typeof(long), 0x2F, true, DataType.SIGNED_64_BIT_INTEGER);
-            _codeTypeMapping[0x30] = new ZclDataType("8-bit Enumeration", typeof(byte), 0x30, false, DataType.ENUMERATION_8_BIT);
-            _codeTypeMapping[0x31] = new ZclDataType("16-bit Enumeration", typeof(ushort), 0x31, false, DataType.ENUMERATION_16_BIT);
-            _codeTypeMapping[0x33] = new ZclDataType("32-bit Enumeration", typeof(uint), 0x33, false, DataType.ENUMERATION_32_BIT);
-            _codeTypeMapping[0x38] = new ZclDataType("Semi precision float", typeof(float), 0x38, true, DataType.FLOAT_16_BIT);
-            _codeTypeMapping[0x39] = new ZclDataType("Single precision float", typeof(float), 0x39, true, DataType.FLOAT_32_BIT);
-            _codeTypeMapping[0x3A] = new ZclDataType("Double precision float", typeof(double), 0x3A, true, DataType.FLOAT_64_BIT);
-            _codeTypeMapping[0x41] = new ZclDataType("Octet string", typeof(ByteArray), 0x41, false, DataType.OCTET_STRING);
-            _codeTypeMapping[0x42] = new ZclDataType("Character String", typeof(string), 0x42, false, DataType.CHARACTER_STRING);
-            _codeTypeMapping[0x43] = new ZclDataType("Long Octet string", typeof(ByteArray), 0x43, false, DataType.LONG_OCTET_STRING);
-            _codeTypeMapping[0x44] = new ZclDataType("Long Character String", typeof(string), 0x44, false, DataType.LONG_CHARACTER_STRING);
-            _codeTypeMapping[0x48] = new ZclDataType("ARRAY", null, 0x48, false, DataType.ORDERED_SEQUENCE_ARRAY);
-            _codeTypeMapping[0x4C] = new ZclDataType("ORDERED_SEQUENCE_STRUCTURE", null, 0x4C, false, DataType.ORDERED_SEQUENCE_STRUCTURE);
-            _codeTypeMapping[0x50] = new ZclDataType("SET", null, 0x50, false, DataType.COLLECTION_SET);
-            _codeTypeMapping[0x51] = new ZclDataType("COLLECTION_BAG", null, 0x51, false, DataType.COLLECTION_BAG);
-            _codeTypeMapping[0xE0] = new ZclDataType("Time", null, 0xE0, true, DataType.TIME_OF_DAY);
-            _codeTypeMapping[0xE1] = new ZclDataType("Date", null, 0xE1, true, DataType.DATE);
-            _codeTypeMapping[0xE2] = new ZclDataType("UTCTime", typeof(DateTime), 0xE2, true, DataType.UTCTIME);
-            _codeTypeMapping[0xE8] = new ZclDataType("ClusterId", typeof(int), 0xE8, false, DataType.CLUSTERID);
-            _codeTypeMapping[0xE9] = new ZclDataType("AttributeId", null, 0xE9, false, DataType.ATTRIBUTEID);
-            _codeTypeMapping[0xEA] = new ZclDataType("BACNetId", null, 0xEA, false, DataType.BACNET_OID);
-            _codeTypeMapping[0xF0] = new ZclDataType("IEEE Address", typeof(IeeeAddress), 0xF0, false, DataType.IEEE_ADDRESS);
-            _codeTypeMapping[0xF1] = new ZclDataType("ZigBee Key", typeof(ZigBeeKey), 0xF1, false, DataType.SECURITY_KEY);
+            Add( new ZclDataType("8-bit data", typeof(byte), 0x08, false, DataType.DATA_8_BIT) );
+            Add( new ZclDataType("16-bit data", null, 0x09, false, DataType.DATA_16_BIT) );
+            Add( new ZclDataType("24-bit data", null, 0x0A, false, DataType.DATA_24_BIT) );
+            Add( new ZclDataType("32-bit data", null, 0x0B, false, DataType.DATA_32_BIT) );
+            Add( new ZclDataType("40-bit data", null, 0x0C, false, DataType.DATA_40_BIT) );
+            Add( new ZclDataType("48-bit data", null, 0x0D, false, DataType.DATA_48_BIT) );
+            Add( new ZclDataType("56-bit data", null, 0x0E, false, DataType.DATA_56_BIT) );
+            Add( new ZclDataType("64-bit data", null, 0x0F, false, DataType.DATA_64_BIT) );
+            Add( new ZclDataType("Boolean", typeof(bool), 0x10, false, DataType.BOOLEAN) );
+            Add( new ZclDataType("8-bit Bitmap", typeof(byte), 0x18, false, DataType.BITMAP_8_BIT) );
+            Add( new ZclDataType("16-bit Bitmap", typeof(ushort), 0x19, false, DataType.BITMAP_16_BIT) );
+            Add( new ZclDataType("24-bit Bitmap", typeof(uint), 0x1A, false, DataType.BITMAP_24_BIT) );
+            Add( new ZclDataType("32-bit Bitmap", typeof(uint), 0x1B, false, DataType.BITMAP_32_BIT) );
+            Add( new ZclDataType("40-bit Bitmap", typeof(ulong), 0x1C, false, DataType.BITMAP_40_BIT) );
+            Add( new ZclDataType("48-bit Bitmap", typeof(ulong), 0x1D, false, DataType.BITMAP_48_BIT) );
+            Add( new ZclDataType("56-bit Bitmap", typeof(ulong), 0x1E, false, DataType.BITMAP_56_BIT) );
+            Add( new ZclDataType("64-bit Bitmap", typeof(ulong), 0x1F, false, DataType.BITMAP_64_BIT) );
+            Add( new ZclDataType("Unsigned 8-bit integer", typeof(byte), 0x20, true, DataType.UNSIGNED_8_BIT_INTEGER) );
+            Add( new ZclDataType("Unsigned 16-bit integer", typeof(ushort), 0x21, true, DataType.UNSIGNED_16_BIT_INTEGER) );
+            Add( new ZclDataType("Unsigned 24-bit integer", typeof(uint), 0x22, true, DataType.UNSIGNED_24_BIT_INTEGER) );
+            Add( new ZclDataType("Unsigned 32-bit integer", typeof(uint), 0x23, true, DataType.UNSIGNED_32_BIT_INTEGER) );
+            Add( new ZclDataType("Unsigned 40-bit integer", typeof(ulong), 0x24, true, DataType.UNSIGNED_40_BIT_INTEGER) );
+            Add( new ZclDataType("Unsigned 48-bit integer", typeof(ulong), 0x25, true, DataType.UNSIGNED_48_BIT_INTEGER) );
+            Add( new ZclDataType("Unsigned 56-bit integer", typeof(ulong), 0x26, true, DataType.UNSIGNED_56_BIT_INTEGER) );
+            Add( new ZclDataType("Unsigned 64-bit integer", typeof(ulong), 0x27, true, DataType.UNSIGNED_64_BIT_INTEGER) );
+            Add( new ZclDataType("Signed 8-bit Integer", typeof(sbyte), 0x28, true, DataType.SIGNED_8_BIT_INTEGER) );
+            Add( new ZclDataType("Signed 16-bit Integer", typeof(short), 0x29, true, DataType.SIGNED_16_BIT_INTEGER) );
+            Add( new ZclDataType("Signed 24-bit Integer", typeof(int), 0x2A, true, DataType.SIGNED_24_BIT_INTEGER) );
+            Add( new ZclDataType("Signed 32-bit Integer", typeof(int), 0x2B, true, DataType.SIGNED_32_BIT_INTEGER) );
+            Add( new ZclDataType("Signed 40-bit Integer", typeof(long), 0x2C, true, DataType.SIGNED_40_BIT_INTEGER) );
+            Add( new ZclDataType("Signed 48-bit Integer", typeof(long), 0x2D, true, DataType.SIGNED_48_BIT_INTEGER) );
+            Add( new ZclDataType("Signed 56-bit Integer", typeof(long), 0x2E, true, DataType.SIGNED_56_BIT_INTEGER) );
+            Add( new ZclDataType("Signed 64-bit Integer", typeof(long), 0x2F, true, DataType.SIGNED_64_BIT_INTEGER) );
+            Add( new ZclDataType("8-bit Enumeration", typeof(byte), 0x30, false, DataType.ENUMERATION_8_BIT) );
+            Add( new ZclDataType("16-bit Enumeration", typeof(ushort), 0x31, false, DataType.ENUMERATION_16_BIT) );
+            Add( new ZclDataType("32-bit Enumeration", typeof(uint), 0x32, false, DataType.ENUMERATION_32_BIT) );
+            Add( new ZclDataType("Semi precision float", typeof(float), 0x38, true, DataType.FLOAT_16_BIT) );
+            Add( new ZclDataType("Single precision float", typeof(float), 0x39, true, DataType.FLOAT_32_BIT) );
+            Add( new ZclDataType("Double precision float", typeof(double), 0x3A, true, DataType.FLOAT_64_BIT) );
+            Add( new ZclDataType("Octet string", typeof(ByteArray), 0x41, false, DataType.OCTET_STRING) );
+            Add( new ZclDataType("Character String", typeof(string), 0x42, false, DataType.CHARACTER_STRING) );
+            Add( new ZclDataType("Long Octet string", typeof(ByteArray), 0x43, false, DataType.LONG_OCTET_STRING) );
+            Add( new ZclDataType("Long Character String", typeof(string), 0x44, false, DataType.LONG_CHARACTER_STRING) );
+            Add( new ZclDataType("ARRAY", null, 0x48, false, DataType.ORDERED_SEQUENCE_ARRAY) );
+            Add( new ZclDataType("ORDERED_SEQUENCE_STRUCTURE", null, 0x4C, false, DataType.ORDERED_SEQUENCE_STRUCTURE) );
+            Add( new ZclDataType("SET", null, 0x50, false, DataType.COLLECTION_SET) );
+            Add( new ZclDataType("COLLECTION_BAG", null, 0x51, false, DataType.COLLECTION_BAG) );
+            Add( new ZclDataType("Time", null, 0xE0, true, DataType.TIME_OF_DAY) );
+            Add( new ZclDataType("Date", null, 0xE1, true, DataType.DATE) );
+            Add( new ZclDataType("UTCTime", typeof(DateTime), 0xE2, true, DataType.UTCTIME) );
+            Add( new ZclDataType("ClusterId", typeof(int), 0xE8, false, DataType.CLUSTERID) );
+            Add( new ZclDataType("AttributeId", null, 0xE9, false, DataType.ATTRIBUTEID) );
+            Add( new ZclDataType("BACNetId", null, 0xEA, false, DataType.BACNET_OID) );
+            Add( new ZclDataType("IEEE Address", typeof(IeeeAddress), 0xF0, false, DataType.IEEE_ADDRESS) );
+            Add( new ZclDataType("ZigBee Key", typeof(ZigBeeKey), 0xF1, false, DataType.SECURITY_KEY) );
 
-            _codeTypeMapping[0x80] = new ZclDataType("Byte array", typeof(ByteArray), 0x00, false, DataType.BYTE_ARRAY);
-            _codeTypeMapping[0x81] = new ZclDataType("N X Attribute identifier", typeof(ushort), 0x00, false, DataType.N_X_ATTRIBUTE_IDENTIFIER);
-            _codeTypeMapping[0x82] = new ZclDataType("N X Attribute information", typeof(AttributeInformation), 0x00, false, DataType.N_X_ATTRIBUTE_INFORMATION);
-            _codeTypeMapping[0x83] = new ZclDataType("N X Attribute record", typeof(AttributeRecord), 0x00, false, DataType.N_X_ATTRIBUTE_RECORD);
-            _codeTypeMapping[0x84] = new ZclDataType("N X Attribute report", typeof(AttributeReport), 0x00, false, DataType.N_X_ATTRIBUTE_REPORT);
-            _codeTypeMapping[0x85] = new ZclDataType("N X Attribute reporting status record", typeof(AttributeReportingStatusRecord), 0x00, false, DataType.N_X_ATTRIBUTE_REPORTING_STATUS_RECORD);
-            _codeTypeMapping[0x86] = new ZclDataType("N X Attribute reporting configuration record", typeof(AttributeReportingConfigurationRecord), 0x00, false, DataType.N_X_ATTRIBUTE_REPORTING_CONFIGURATION_RECORD);
-            _codeTypeMapping[0x87] = new ZclDataType("N X Attribute selector", typeof(object), 0x00, false, DataType.N_X_ATTRIBUTE_SELECTOR);
-            _codeTypeMapping[0x88] = new ZclDataType("N X Attribute status record", typeof(AttributeStatusRecord), 0x00, false, DataType.N_X_ATTRIBUTE_STATUS_RECORD);
-            _codeTypeMapping[0x89] = new ZclDataType("N x Extended Attribute Information", typeof(ExtendedAttributeInformation), 0x00, false, DataType.N_X_EXTENDED_ATTRIBUTE_INFORMATION);
-            _codeTypeMapping[0x8A] = new ZclDataType("N X Extension field set", typeof(ExtensionFieldSet), 0x00, false, DataType.N_X_EXTENSION_FIELD_SET);
-            _codeTypeMapping[0x8B] = new ZclDataType("N X Neighbors information", typeof(NeighborInformation), 0x00, false, DataType.N_X_NEIGHBORS_INFORMATION);
-            _codeTypeMapping[0x8C] = new ZclDataType("N X Read attribute status record", typeof(ReadAttributeStatusRecord), 0x00, false, DataType.N_X_READ_ATTRIBUTE_STATUS_RECORD);
-            _codeTypeMapping[0x8D] = new ZclDataType("N x Unsigned 8-bit Integer", typeof(List<byte>), 0x00, false, DataType.N_X_UNSIGNED_8_BIT_INTEGER);
-            _codeTypeMapping[0x8E] = new ZclDataType("N X Unsigned 16-bit integer", typeof(List<ushort>), 0x00, false, DataType.N_X_UNSIGNED_16_BIT_INTEGER);
-            _codeTypeMapping[0x8F] = new ZclDataType("N X Write attribute record", typeof(WriteAttributeRecord), 0x00, false, DataType.N_X_WRITE_ATTRIBUTE_RECORD);
-            _codeTypeMapping[0x90] = new ZclDataType("N X Write attribute status record", typeof(WriteAttributeStatusRecord), 0x00, false, DataType.N_X_WRITE_ATTRIBUTE_STATUS_RECORD);
-            _codeTypeMapping[0x91] = new ZclDataType("X Unsigned 8-bit integer", typeof(List<byte>), 0x00, false, DataType.X_UNSIGNED_8_BIT_INTEGER);
-            _codeTypeMapping[0x92] = new ZclDataType("Zcl Status", typeof(ZclStatus), 0x00, false, DataType.ZCL_STATUS);
-            _codeTypeMapping[0x93] = new ZclDataType("EXTENDED_PANID", typeof(ExtendedPanId), 0x00, false, DataType.EXTENDED_PANID);
-            _codeTypeMapping[0x94] = new ZclDataType("Binding Table", typeof(BindingTable), 0x00, false, DataType.BINDING_TABLE);
-            _codeTypeMapping[0x95] = new ZclDataType("Complex Descriptor", typeof(ComplexDescriptor), 0x00, false, DataType.COMPLEX_DESCRIPTOR);
-            _codeTypeMapping[0x96] = new ZclDataType("Endpoint", typeof(int), 0x00, false, DataType.ENDPOINT);
-            _codeTypeMapping[0x97] = new ZclDataType("Neighbor Table", typeof(NeighborTable), 0x00, false, DataType.NEIGHBOR_TABLE);
-            _codeTypeMapping[0x98] = new ZclDataType("Node Descriptor", typeof(NodeDescriptor), 0x00, false, DataType.NODE_DESCRIPTOR);
-            _codeTypeMapping[0x99] = new ZclDataType("NWK address", typeof(ushort), 0x00, false, DataType.NWK_ADDRESS);
-            _codeTypeMapping[0x9A] = new ZclDataType("N x Binding Table", typeof(BindingTable), 0x00, false, DataType.N_X_BINDING_TABLE);
-            _codeTypeMapping[0x9B] = new ZclDataType("N X IEEE Address", typeof(ulong), 0x00, false, DataType.N_X_IEEE_ADDRESS);
-            _codeTypeMapping[0x9C] = new ZclDataType("Power Descriptor", typeof(PowerDescriptor), 0x00, false, DataType.POWER_DESCRIPTOR);
-            _codeTypeMapping[0x9D] = new ZclDataType("Routing Table", typeof(RoutingTable), 0x00, false, DataType.ROUTING_TABLE);
-            _codeTypeMapping[0x9E] = new ZclDataType("Simple Descriptor", typeof(SimpleDescriptor), 0x00, false, DataType.SIMPLE_DESCRIPTOR);
-            _codeTypeMapping[0x9F] = new ZclDataType("User Descriptor", typeof(UserDescriptor), 0x00, false, DataType.USER_DESCRIPTOR);
-            _codeTypeMapping[0xA0] = new ZclDataType("Zdo Status", typeof(ZdoStatus), 0x00, false, DataType.ZDO_STATUS);
-            _codeTypeMapping[0xA1] = new ZclDataType("Unsigned 8 bit Integer Array", typeof(byte[]), 0x00, false, DataType.UNSIGNED_8_BIT_INTEGER_ARRAY);
-            _codeTypeMapping[0xA2] = new ZclDataType("RAW_OCTET", typeof(ByteArray), 0x00, false, DataType.RAW_OCTET);
-            _codeTypeMapping[0xA3] = new ZclDataType("ZigBee Data Type", typeof(ZclDataType), 0x00, false, DataType.ZIGBEE_DATA_TYPE);
+            Add( new ZclDataType("Byte array", typeof(ByteArray), 0x00, false, DataType.BYTE_ARRAY) );
+            Add( new ZclDataType("N X Attribute identifier", typeof(ushort), 0x00, false, DataType.N_X_ATTRIBUTE_IDENTIFIER) );
+            Add( new ZclDataType("N X Attribute information", typeof(AttributeInformation), 0x00, false, DataType.N_X_ATTRIBUTE_INFORMATION) );
+            Add( new ZclDataType("N X Attribute record", typeof(AttributeRecord), 0x00, false, DataType.N_X_ATTRIBUTE_RECORD) );
+            Add( new ZclDataType("N X Attribute report", typeof(AttributeReport), 0x00, false, DataType.N_X_ATTRIBUTE_REPORT) );
+            Add( new ZclDataType("N X Attribute reporting status record", typeof(AttributeReportingStatusRecord), 0x00, false, DataType.N_X_ATTRIBUTE_REPORTING_STATUS_RECORD) );
+            Add( new ZclDataType("N X Attribute reporting configuration record", typeof(AttributeReportingConfigurationRecord), 0x00, false, DataType.N_X_ATTRIBUTE_REPORTING_CONFIGURATION_RECORD) );
+            Add( new ZclDataType("N X Attribute selector", typeof(object), 0x00, false, DataType.N_X_ATTRIBUTE_SELECTOR) );
+            Add( new ZclDataType("N X Attribute status record", typeof(AttributeStatusRecord), 0x00, false, DataType.N_X_ATTRIBUTE_STATUS_RECORD) );
+            Add( new ZclDataType("N x Extended Attribute Information", typeof(ExtendedAttributeInformation), 0x00, false, DataType.N_X_EXTENDED_ATTRIBUTE_INFORMATION) );
+            Add( new ZclDataType("N X Extension field set", typeof(ExtensionFieldSet), 0x00, false, DataType.N_X_EXTENSION_FIELD_SET) );
+            Add( new ZclDataType("N X Neighbors information", typeof(NeighborInformation), 0x00, false, DataType.N_X_NEIGHBORS_INFORMATION) );
+            Add( new ZclDataType("N X Read attribute status record", typeof(ReadAttributeStatusRecord), 0x00, false, DataType.N_X_READ_ATTRIBUTE_STATUS_RECORD) );
+            Add( new ZclDataType("N x Unsigned 8-bit Integer", typeof(List<byte>), 0x00, false, DataType.N_X_UNSIGNED_8_BIT_INTEGER) );
+            Add( new ZclDataType("N X Unsigned 16-bit integer", typeof(List<ushort>), 0x00, false, DataType.N_X_UNSIGNED_16_BIT_INTEGER) );
+            Add( new ZclDataType("N X Write attribute record", typeof(WriteAttributeRecord), 0x00, false, DataType.N_X_WRITE_ATTRIBUTE_RECORD) );
+            Add( new ZclDataType("N X Write attribute status record", typeof(WriteAttributeStatusRecord), 0x00, false, DataType.N_X_WRITE_ATTRIBUTE_STATUS_RECORD) );
+            Add( new ZclDataType("X Unsigned 8-bit integer", typeof(List<byte>), 0x00, false, DataType.X_UNSIGNED_8_BIT_INTEGER) );
+            Add( new ZclDataType("Zcl Status", typeof(ZclStatus), 0x00, false, DataType.ZCL_STATUS) );
+            Add( new ZclDataType("EXTENDED_PANID", typeof(ExtendedPanId), 0x00, false, DataType.EXTENDED_PANID) );
+            Add( new ZclDataType("Binding Table", typeof(BindingTable), 0x00, false, DataType.BINDING_TABLE) );
+            Add( new ZclDataType("Complex Descriptor", typeof(ComplexDescriptor), 0x00, false, DataType.COMPLEX_DESCRIPTOR) );
+            Add( new ZclDataType("Endpoint", typeof(int), 0x00, false, DataType.ENDPOINT) );
+            Add( new ZclDataType("Neighbor Table", typeof(NeighborTable), 0x00, false, DataType.NEIGHBOR_TABLE) );
+            Add( new ZclDataType("Node Descriptor", typeof(NodeDescriptor), 0x00, false, DataType.NODE_DESCRIPTOR) );
+            Add( new ZclDataType("NWK address", typeof(ushort), 0x00, false, DataType.NWK_ADDRESS) );
+            Add( new ZclDataType("N x Binding Table", typeof(BindingTable), 0x00, false, DataType.N_X_BINDING_TABLE) );
+            Add( new ZclDataType("N X IEEE Address", typeof(ulong), 0x00, false, DataType.N_X_IEEE_ADDRESS) );
+            Add( new ZclDataType("Power Descriptor", typeof(PowerDescriptor), 0x00, false, DataType.POWER_DESCRIPTOR) );
+            Add( new ZclDataType("Routing Table", typeof(RoutingTable), 0x00, false, DataType.ROUTING_TABLE) );
+            Add( new ZclDataType("Simple Descriptor", typeof(SimpleDescriptor), 0x00, false, DataType.SIMPLE_DESCRIPTOR) );
+            Add( new ZclDataType("User Descriptor", typeof(UserDescriptor), 0x00, false, DataType.USER_DESCRIPTOR) );
+            Add( new ZclDataType("Zdo Status", typeof(ZdoStatus), 0x00, false, DataType.ZDO_STATUS) );
+            Add( new ZclDataType("Unsigned 8 bit Integer Array", typeof(byte[]), 0x00, false, DataType.UNSIGNED_8_BIT_INTEGER_ARRAY) );
+            Add( new ZclDataType("RAW_OCTET", typeof(ByteArray), 0x00, false, DataType.RAW_OCTET) );
+            Add( new ZclDataType("ZigBee Data Type", typeof(ZclDataType), 0x00, false, DataType.ZIGBEE_DATA_TYPE) );
         }
 
-        public static ZclDataType Get(int id)
+        public static ZclDataType Get(byte id)
         {
             return _codeTypeMapping[id];
-        }
-
+        } 
+        
         public static ZclDataType Get(DataType type)
         {
-            return _codeTypeMapping[(int)type];
+            return _codeTypeMapping[(byte)type];
         }
-
+        
         public override string ToString()
         {
             return Label;

--- a/libraries/ZigBeeNet/ZigBeeNetworkManager.cs
+++ b/libraries/ZigBeeNet/ZigBeeNetworkManager.cs
@@ -187,7 +187,7 @@ namespace ZigBeeNet
         /// <summary>
         /// The default ProfileID to use
         /// </summary>
-        private int _defaultProfileId = ZigBeeProfileType.Get(ProfileType.ZIGBEE_HOME_AUTOMATION).Key;
+        private ushort _defaultProfileId = (ushort)ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION;
 
         public ZigBeeChannel ZigbeeChannel
         {

--- a/libraries/ZigBeeNet/ZigBeeProfileType.cs
+++ b/libraries/ZigBeeNet/ZigBeeProfileType.cs
@@ -1,80 +1,38 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace ZigBeeNet
 {
-
-    public enum ProfileType
+    public enum ZigBeeProfileType : ushort
     {
         /// <summary>
          /// ZigBee Home Automation
          /// </summary>
-        ZIGBEE_HOME_AUTOMATION,
+        ZIGBEE_HOME_AUTOMATION = 0x0104,
 
         /// <summary>
          /// ZigBee Smart Energy
          /// </summary>
-        ZIGBEE_SMART_ENERGY,
+        ZIGBEE_SMART_ENERGY = 0x0109,
 
         /// <summary>
          /// ZigBee Green Power
          /// </summary>
-        ZIGBEE_GREEN_POWER,
+        ZIGBEE_GREEN_POWER = 0xA10E,
 
         /// <summary>
          /// Manufacturer Telegesis
          /// </summary>
-        MANUFACTURER_TELEGESIS,
+        MANUFACTURER_TELEGESIS = 0xC059,
 
         /// <summary>
          /// ZigBee Light Link
          /// </summary>
-        ZIGBEE_LIGHT_LINK,
+        ZIGBEE_LIGHT_LINK = 0xC05E,
 
         /// <summary>
          /// Manufacturer Digi
          /// </summary>
-        MANUFACTURER_DIGI,
-    }
-
-    public class ZigBeeProfileType
-    {
-        private static readonly Dictionary<int, ZigBeeProfileType> _idMap;
-
-        public int Key { get; private set; }
-
-        public ProfileType ProfileType { get; private set; }
-
-
-        private ZigBeeProfileType(int key, ProfileType profileType)
-        {
-            Key = key;
-            ProfileType = profileType;
-        }
-
-        static ZigBeeProfileType()
-        {
-            _idMap = new Dictionary<int, ZigBeeProfileType>
-            {
-                { 0x0104, new ZigBeeProfileType(0x0104, ProfileType.ZIGBEE_HOME_AUTOMATION) },
-                { 0x0109, new ZigBeeProfileType(0x0109, ProfileType.ZIGBEE_SMART_ENERGY) },
-                { 0xA10E, new ZigBeeProfileType(0xA10E, ProfileType.ZIGBEE_GREEN_POWER) },
-                { 0xC059, new ZigBeeProfileType(0xA10E, ProfileType.MANUFACTURER_TELEGESIS) },
-                { 0xC05E, new ZigBeeProfileType(0xC05E, ProfileType.ZIGBEE_LIGHT_LINK) },
-                { 0xC105, new ZigBeeProfileType(0xC105, ProfileType.MANUFACTURER_DIGI) },
-            };
-        }
-
-        public static ZigBeeProfileType Get(int value)
-        {
-            return _idMap[value];
-        }
-
-        public static ZigBeeProfileType Get(ProfileType profileType)
-        {
-            return _idMap.Values.Single(pt => pt.ProfileType == profileType);
-        }
+        MANUFACTURER_DIGI = 0xC105,
     }
 }

--- a/libraries/ZigbeeNet.Hardware.Ember/ZigBeeDongleEzsp.cs
+++ b/libraries/ZigbeeNet.Hardware.Ember/ZigBeeDongleEzsp.cs
@@ -118,7 +118,7 @@ namespace ZigBeeNet.Hardware.Ember
         /**
          * The default ProfileID to use
          */
-        private int _defaultProfileId = ZigBeeProfileType.Get(ProfileType.ZIGBEE_HOME_AUTOMATION).Key;
+        private ushort _defaultProfileId = (ushort)ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION;
 
         /**
          * The default DeviceID to use
@@ -302,7 +302,7 @@ namespace ZigBeeNet.Hardware.Ember
         }
         */
 
-        public void SetDefaultProfileId(int defaultProfileId) 
+        public void SetDefaultProfileId(ushort defaultProfileId) 
         {
             this._defaultProfileId = defaultProfileId;
         }


### PR DESCRIPTION
In `ZclDataType`, the use of `Linq` and `Single` results in enumerating the complete `Dictionary` each time the `Get(DataType type)` function is called. This has a serious performance impact as this function is called a lot from cluster classes (see first line of benchmark below).

First step was thus to refactor the function to effectively use the `Dictionary` (around 150x improvement).

Then I had the intuition that a `Dictionary` wasn't the most efficient way to implement that function. So I made some performance and memory benchmarks to check 3 alternatives to Dictionary: a class derived from `KeyedCollection`, an `Array[16][16]` that contains only no empty rows and a simple `Array[256]`, the first giving a small memory advantage.

After analysis it appears that using a simple `Array[256]` is really giving a performance advantage and that the memory cost of that approach is lower than the `Dictionary`, even if this can be counter-intuitive at first glance. So I changed the class to use the simple array approach.

I also changed the `ZigBeeProfileType` to a pure `Enum` approach which is sufficient for that class. 


### Benchmark results

In the tables below : Get -> original Get function, *Dict -> using the Dictionary, *KeyedValue -> using a KeyedCollection, *SquareArray -> using Array[16][16], Array -> using Array[256]

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i5-5200U CPU 2.20GHz (Broadwell), 1 CPU, 4 logical and 2 physical cores
.NET Core SDK=3.1.407
  [Host]     : .NET Core 3.1.13 (CoreCLR 4.700.21.11102, CoreFX 4.700.21.11602), X64 RyuJIT
  DefaultJob : .NET Core 3.1.13 (CoreCLR 4.700.21.11102, CoreFX 4.700.21.11602), X64 RyuJIT
```
|         Method |          Mean |      Error |     StdDev |
|--------------- |--------------:|-----------:|-----------:|
|            Get | 1,464.0581 ns | 14.1086 ns | 11.7813 ns |
|        GetDict |    10.2695 ns |  0.1114 ns |  0.0870 ns |
|  GetKeyedValue |    18.2015 ns |  0.4702 ns |  0.5775 ns |
| GetSquareArray |     2.7174 ns |  0.1224 ns |  0.1085 ns |
|       GetArray |     0.4355 ns |  0.0930 ns |  0.0870 ns |

|            Method |       Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------ |-----------:|---------:|---------:|-------:|------:|------:|----------:|
|        CreateDict | 1,979.5 ns | 38.69 ns | 66.74 ns | 1.9875 |     - |     - |   3.05 KB |
|  CreateKeyedValue | 6,579.2 ns | 70.85 ns | 59.16 ns | 7.9041 |     - |     - |  12.13 KB |
|       CreateArray |   549.6 ns | 10.62 ns |  9.93 ns | 1.3351 |     - |     - |   2.05 KB |
| CreateSquareArray | 1,157.4 ns | 22.45 ns | 25.86 ns | 1.1768 |     - |     - |    1.8 KB |