### PR TITLE
Fix ConBee2 with firmware 0x26660700 or newer

### DIFF
--- a/libraries/ZigbeeNet.Hardware.ConBee/Internal/ConBeeInterface.cs
+++ b/libraries/ZigbeeNet.Hardware.ConBee/Internal/ConBeeInterface.cs
@@ -391,7 +391,7 @@ namespace ZigbeeNet.Hardware.ConBee
 
         public async Task<string> GetVersionAsync()
         {
-            var response = await SendAsync(Commands.VERSION).ConfigureAwait(false);
+            var response = await SendAsync(Commands.VERSION, new byte[4]).ConfigureAwait(false);
             string result;
             switch (response[6])
             {


### PR DESCRIPTION
Copy paste from documentation:
Due a regression in firmware version 0x26660700 the additional empty U32
‘Reserved’ field needs to be part of the request, which raises the frame length from 5 to 9.
Older versions also accept the additional field.