### PR TITLE
ZigBeeNode refactor / json-mongodb stores fix

### DIFF
--- a/libraries/ZigBeeNet.DataStore.Json/JsonNetworkDataStore.cs
+++ b/libraries/ZigBeeNet.DataStore.Json/JsonNetworkDataStore.cs
@@ -1,7 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Newtonsoft.Json.Converters;
 using ZigBeeNet.Database;
 
 namespace ZigBeeNet.DataStore.Json
@@ -9,6 +12,11 @@ namespace ZigBeeNet.DataStore.Json
     public class JsonNetworkDataStore : IZigBeeNetworkDataStore
     {
         private readonly string _dirname;
+        static private readonly JsonSerializerSettings _settings = new JsonSerializerSettings()
+                {
+                    ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+                    ContractResolver = new PrivateResolver(),
+                };
 
         public JsonNetworkDataStore(string dirname)
         {
@@ -65,7 +73,7 @@ namespace ZigBeeNet.DataStore.Json
 
                 if (File.Exists(filename))
                 {
-                    node = JsonConvert.DeserializeObject<ZigBeeNodeDao>(File.ReadAllText(filename));
+                    node = JsonConvert.DeserializeObject<ZigBeeNodeDao>(File.ReadAllText(filename),_settings);
                 }
             }
             catch (Exception ex)
@@ -98,12 +106,7 @@ namespace ZigBeeNet.DataStore.Json
             {
                 string filename = GetFileName(node.IeeeAddress);
 
-                var settings = new JsonSerializerSettings()
-                {
-                    ReferenceLoopHandling = ReferenceLoopHandling.Ignore
-                };
-
-                string json = JsonConvert.SerializeObject(node, Formatting.Indented, settings);
+                string json = JsonConvert.SerializeObject(node, Formatting.Indented, _settings);
 
                 File.WriteAllText(filename, json);
             }
@@ -112,5 +115,21 @@ namespace ZigBeeNet.DataStore.Json
                 Console.WriteLine(ex.ToString());
             }
         }
+
+        // Private resolver to configure Newtonsoft.Json to deserialize properties with private setter
+        // Credit : https://talkdotnet.wordpress.com/2019/03/15/newtonsoft-json-deserializing-objects-that-have-private-setters/
+        public class PrivateResolver : DefaultContractResolver
+        {
+            protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+            {
+                JsonProperty prop = base.CreateProperty(member, memberSerialization);
+                if (!prop.Writable) {
+                    PropertyInfo property = member as PropertyInfo;
+                    bool hasPrivateSetter = property?.GetSetMethod(true) != null;
+                    prop.Writable = hasPrivateSetter;
+                }
+                return prop;
+            }
+        }        
     }
 }

--- a/libraries/ZigBeeNet.Hardware.Digi.XBee/Internal/Protocol/XBeeFrame.cs
+++ b/libraries/ZigBeeNet.Hardware.Digi.XBee/Internal/Protocol/XBeeFrame.cs
@@ -199,9 +199,10 @@ namespace ZigBeeNet.Hardware.Digi.XBee.Internal.Protocol
         /// <param name="address">The IeeeAddress <seealso cref="IeeeAddress"/></param>
         protected void SerializeIeeeAddress(IeeeAddress address)
         {
+            var a=address.GetAddress();
             for (int cnt = 7; cnt >= 0; cnt--)
             {
-                _buffer[_length++] = address.GetAddress()[cnt];
+                _buffer[_length++] = a[cnt];
             }
         }
 

--- a/libraries/ZigBeeNet.Hardware.Digi.XBee/ZigBeeDongleXBee.cs
+++ b/libraries/ZigBeeNet.Hardware.Digi.XBee/ZigBeeDongleXBee.cs
@@ -23,8 +23,8 @@ namespace ZigBeeNet.Hardware.Digi.XBee
         private bool _coordinatorStarted;
         private bool _initialisationComplete;
 
-        private readonly IeeeAddress _groupIeeeAddress = new IeeeAddress(BigInteger.Parse("000000000000FFFE", NumberStyles.HexNumber));
-        private readonly IeeeAddress _broadcastIeeeAddress = new IeeeAddress(BigInteger.Parse("000000000000FFFF", NumberStyles.HexNumber));
+        private readonly IeeeAddress _groupIeeeAddress = new IeeeAddress(0x0000_0000_0000_FFFEul);
+        private readonly IeeeAddress _broadcastIeeeAddress = new IeeeAddress(0x0000_0000_0000_FFFFul);
 
         private const int MAX_RESET_RETRIES = 3;
 
@@ -269,7 +269,7 @@ namespace ZigBeeNet.Hardware.Digi.XBee
                 {
                     command.SetIeeeAddress(_groupIeeeAddress);
                 }
-                command.SetIeeeAddress(new IeeeAddress(BigInteger.Parse("FFFFFFFFFFFFFFFF", NumberStyles.HexNumber)));
+                command.SetIeeeAddress(new IeeeAddress(0xFFFF_FFFF_FFFF_FFFFul));
             }
             else
             {

--- a/libraries/ZigBeeNet/App/Discovery/ZigBeeNetworkDiscoverer.cs
+++ b/libraries/ZigBeeNet/App/Discovery/ZigBeeNetworkDiscoverer.cs
@@ -194,7 +194,7 @@ namespace ZigBeeNet.App.Discovery
                     {
                         // Request basic response, start index for associated list is 0
                         IeeeAddressRequest ieeeAddressRequest = new IeeeAddressRequest();
-                        ieeeAddressRequest.DestinationAddress = new ZigBeeEndpointAddress(ZigBeeBroadcastDestination.GetBroadcastDestination(BroadcastDestination.BROADCAST_RX_ON).Key);
+                        ieeeAddressRequest.DestinationAddress = ZigBeeEndpointAddress.BROADCAST_RX_ON;
                         ieeeAddressRequest.RequestType = 0;
                         ieeeAddressRequest.StartIndex = 0;
                         ieeeAddressRequest.NwkAddrOfInterest = networkAddress;
@@ -273,7 +273,7 @@ namespace ZigBeeNet.App.Discovery
                         request.IeeeAddr = ieeeAddress;
                         request.RequestType = 0;
                         request.StartIndex = 0;
-                        request.DestinationAddress = new ZigBeeEndpointAddress(ZigBeeBroadcastDestination.GetBroadcastDestination(BroadcastDestination.BROADCAST_RX_ON).Key);
+                        request.DestinationAddress = ZigBeeEndpointAddress.BROADCAST_RX_ON;
                         CommandResult response = await _networkManager.SendTransaction(request, request);
 
                         NetworkAddressResponse nwkAddressResponse = response.GetResponse<NetworkAddressResponse>();
@@ -439,7 +439,7 @@ namespace ZigBeeNet.App.Discovery
             request.RequestType = 0;
             request.StartIndex = 0;
             request.NwkAddrOfInterest = networkAddress;
-            request.DestinationAddress = new ZigBeeEndpointAddress(ZigBeeBroadcastDestination.GetBroadcastDestination(BroadcastDestination.BROADCAST_RX_ON).Key);
+            request.DestinationAddress = ZigBeeEndpointAddress.BROADCAST_RX_ON;
             CommandResult response = await _networkManager.SendTransaction(request, request);
 
             if (response.IsError())

--- a/libraries/ZigBeeNet/App/Discovery/ZigBeeNodeServiceDiscoverer.cs
+++ b/libraries/ZigBeeNet/App/Discovery/ZigBeeNodeServiceDiscoverer.cs
@@ -386,7 +386,7 @@ namespace ZigBeeNet.App.Discovery
             networkAddressRequest.IeeeAddr = Node.IeeeAddress;
             networkAddressRequest.RequestType = 0x00;
             networkAddressRequest.StartIndex = 0;
-            networkAddressRequest.DestinationAddress = new ZigBeeEndpointAddress(ZigBeeBroadcastDestination.GetBroadcastDestination(BroadcastDestination.BROADCAST_ALL_DEVICES).Key);
+            networkAddressRequest.DestinationAddress = ZigBeeEndpointAddress.BROADCAST_ALL_DEVICES;
 
             CommandResult response = await NetworkManager.SendTransaction(networkAddressRequest, networkAddressRequest);
             NetworkAddressResponse networkAddressResponse = response.GetResponse<NetworkAddressResponse>();

--- a/libraries/ZigBeeNet/IZigBeeAddress.cs
+++ b/libraries/ZigBeeNet/IZigBeeAddress.cs
@@ -4,12 +4,12 @@ using System.Text;
 
 namespace ZigBeeNet
 {
-    public interface IZigBeeAddress : IComparable<IZigBeeAddress>
+    public interface IZigBeeAddress
     {
         /// <summary>
          /// The network address for this address.
          /// </summary>
-        ushort Address { get; set; }
+        ushort Address { get; }
 
         /// <summary>
          /// Check whether this address is ZigBee group.

--- a/libraries/ZigBeeNet/Internal/ClusterMatcher.cs
+++ b/libraries/ZigBeeNet/Internal/ClusterMatcher.cs
@@ -69,7 +69,7 @@ namespace ZigBeeNet.Internal
                 }
 
                 if (matchRequest.NwkAddrOfInterest != _networkManager.LocalNwkAddress
-                    && !ZigBeeBroadcastDestination.IsBroadcast(matchRequest.NwkAddrOfInterest))
+                    && !ZigBeeBroadcastDestinationHelper.IsBroadcast(matchRequest.NwkAddrOfInterest))
                 {
                     _logger.LogDebug("{ExtPanId}: ClusterMatcher no match to local address", _networkManager.ZigBeeExtendedPanId);
                     return;

--- a/libraries/ZigBeeNet/Util/ByteHelper.Buffer.cs
+++ b/libraries/ZigBeeNet/Util/ByteHelper.Buffer.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Runtime.CompilerServices;
+namespace ZigBeeNet
+{
+    public static partial class ByteHelper
+    {
+
+        public static ulong ToUInt64(this byte[] buffer) => ToUInt64(buffer,0);
+        public static ulong ToUInt64(this byte[] buffer,int offset) => ToUInt64(buffer,ref offset);
+        public static ulong ToUInt64(this byte[] buffer,ref int offset)
+        {
+            if (buffer.Length-offset<8)
+                throw new ArgumentException("Buffer is too small",nameof(buffer));
+            ulong result = buffer[offset++]
+                            | (ulong)buffer[offset++]<<8
+                            | (ulong)buffer[offset++]<<16
+                            | (ulong)buffer[offset++]<<24
+                            | (ulong)buffer[offset++]<<32
+                            | (ulong)buffer[offset++]<<40
+                            | (ulong)buffer[offset++]<<48
+                            | (ulong)buffer[offset++]<<56;
+            return result;
+        }
+
+        public static void FromUInt64(this byte[] buffer,ulong value) => FromUInt64(buffer,0,value);
+        public static void FromUInt64(this byte[] buffer,int offset,ulong value) => FromUInt64(buffer,ref offset,value);
+        public static void FromUInt64(this byte[] buffer,ref int offset,ulong value)
+        {
+            if (buffer.Length-offset<8)
+                throw new ArgumentException("Buffer is too small",nameof(buffer));
+            buffer[offset++] = (byte)(value);
+            buffer[offset++] = (byte)(value>>8);
+            buffer[offset++] = (byte)(value>>16);
+            buffer[offset++] = (byte)(value>>24);
+            buffer[offset++] = (byte)(value>>32);
+            buffer[offset++] = (byte)(value>>40);
+            buffer[offset++] = (byte)(value>>48);
+            buffer[offset++] = (byte)(value>>56);
+        }
+        public static byte[] FromUInt64(ulong value) 
+        {
+            byte[] buffer=new byte[sizeof(ulong)];
+            FromUInt64(buffer,0,value);
+            return buffer;
+        }
+
+        public static uint ToUInt32(this byte[] buffer) => ToUInt32(buffer,0);
+        public static uint ToUInt32(this byte[] buffer,int offset) => ToUInt32(buffer,ref offset);
+        public static uint ToUInt32(this byte[] buffer,ref int offset)
+        {
+            if (buffer.Length-offset<4)
+                throw new ArgumentException("Buffer is too small",nameof(buffer));
+            uint result = buffer[offset++]
+                            | (uint)buffer[offset++]<<8
+                            | (uint)buffer[offset++]<<16
+                            | (uint)buffer[offset++]<<24;
+            return result;
+        }
+
+        public static void FromUInt32(this byte[] buffer,uint value) => FromUInt32(buffer,0,value);
+        public static void FromUInt32(this byte[] buffer,int offset,uint value) => FromUInt32(buffer,ref offset,value);
+        public static void FromUInt32(this byte[] buffer,ref int offset,uint value)
+        {
+            if (buffer.Length-offset<4)
+                throw new ArgumentException("Buffer is too small",nameof(buffer));
+            buffer[offset++] = (byte)(value);
+            buffer[offset++] = (byte)(value>>8);
+            buffer[offset++] = (byte)(value>>16);
+            buffer[offset++] = (byte)(value>>24);
+        }
+        public static byte[] FromUInt32(uint value)
+        {
+            var buffer = new byte[sizeof(UInt32)];
+            FromUInt32(buffer,0,value);
+            return buffer;
+        } 
+    }
+}

--- a/libraries/ZigBeeNet/Util/ByteHelper.cs
+++ b/libraries/ZigBeeNet/Util/ByteHelper.cs
@@ -4,7 +4,7 @@ using System.Text;
 using System.Runtime.CompilerServices;
 namespace ZigBeeNet
 {
-    public static class ByteHelper
+    public static partial class ByteHelper
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ushort ShortFromBytes(byte[] values, int msb, int lsb)
@@ -39,6 +39,7 @@ namespace ZigBeeNet
 
             return result;
         }
+
 
         public static byte[] Slice(this byte[] data, int offset, int len)
         {

--- a/libraries/ZigBeeNet/ZDO/Field/NodeDescriptor.cs
+++ b/libraries/ZigBeeNet/ZDO/Field/NodeDescriptor.cs
@@ -15,13 +15,13 @@ namespace ZigBeeNet.ZDO.Field
         public bool ComplexDescriptorAvailable { get; private set; }
         public ushort ManufacturerCode { get; private set; }
         public LogicalType LogicalNodeType { get; private set; } = LogicalType.UNKNOWN;
-        public List<ServerCapabilitiesType> ServerCapabilities { get; private set; } = new List<ServerCapabilitiesType>();
+        public ServerCapabilitiesType ServerCapabilities { get; private set; }
         public ushort IncomingTransferSize { get; set; }
         public ushort OutgoingTransferSize { get; private set; }
         public bool IsuserDescriptorAvailable { get; private set; }
 
-        public List<FrequencyBandType> FrequencyBands { get; } = new List<FrequencyBandType>();
-        public List<MacCapabilitiesType> MacCapabilities { get; } = new List<MacCapabilitiesType>();
+        public FrequencyBandType FrequencyBands { get; private set; }
+        public MacCapabilitiesType MacCapabilities { get; private set; }
         public bool IsextendedEndpointListAvailable { get; private set; }
         public bool ExtendedSimpleDescriptorListAvailable { get; private set; }
         public int StackCompliance { get; private set; }
@@ -29,30 +29,32 @@ namespace ZigBeeNet.ZDO.Field
         private const int R21_BITMASK = 0xFE00;
         private const int R21_BITSHIFT = 9;
 
-        public enum LogicalType
+        public enum LogicalType : byte
         {
             COORDINATOR = 0,
             ROUTER = 1,
             END_DEVICE = 2,
-            UNKNOWN = 99
+            UNKNOWN = 0xff
         }
 
+        [Flags]
         public enum FrequencyBandType
         {
-            FREQ_868_MHZ,
-            FREQ_902_MHZ,
-            FREQ_2400_MHZ
+            FREQ_868_MHZ = 0x01,
+            FREQ_902_MHZ = 0x02,
+            FREQ_2400_MHZ = 0x04,
         }
 
+        [Flags]
         public enum ServerCapabilitiesType
         {
-            PRIMARY_TRUST_CENTER,
-            BACKUP_TRUST_CENTER,
-            PRIMARY_BINDING_TABLE_CACHE,
-            BACKUP_BINDING_TABLE_CACHE,
-            PRIMARY_DISCOVERY_CACHE,
-            BACKUP_DISCOVERY_CACHE,
-            NETWORK_MANAGER
+            PRIMARY_TRUST_CENTER = 0x01,
+            BACKUP_TRUST_CENTER = 0x02,
+            PRIMARY_BINDING_TABLE_CACHE = 0x04,
+            BACKUP_BINDING_TABLE_CACHE = 0x08,
+            PRIMARY_DISCOVERY_CACHE = 0x10,
+            BACKUP_DISCOVERY_CACHE = 0x20,
+            NETWORK_MANAGER = 0x40,
         }
 
         public enum DescriptorCapabilityType
@@ -63,13 +65,12 @@ namespace ZigBeeNet.ZDO.Field
 
         public enum MacCapabilitiesType
         {
-            ALTERNATIVE_PAN,
-            FULL_FUNCTION_DEVICE,
-            REDUCED_FUNCTION_DEVICE,
-            MAINS_POWER,
-            RECEIVER_ON_WHEN_IDLE,
-            SECURITY_CAPABLE,
-            ADDRESS_ALLOCATION
+            ALTERNATIVE_PAN = 0x01,
+            FULL_FUNCTION_DEVICE = 0x02,
+            //REDUCED_FUNCTION_DEVICE,
+            MAINS_POWER = 0x04,
+            RECEIVER_ON_WHEN_IDLE = 0x08,
+            SECURITY_CAPABLE = 0x40,
         }
 
         public NodeDescriptor()
@@ -77,122 +78,43 @@ namespace ZigBeeNet.ZDO.Field
             // Default constructor - does nothing
         }
 
-        public NodeDescriptor(int apsFlags, byte bufferSize, int macCapabilities, bool complexDescriptorAvailable,
-                ushort manufacturerCode, int logicalType, short serverMask, ushort transferSize, bool userDescriptorAvailable,
-                int frequencyBands)
+        public NodeDescriptor(int apsFlags, byte bufferSize, byte macCapabilities, bool complexDescriptorAvailable,
+                ushort manufacturerCode, byte logicalType, short serverMask, ushort transferSize, bool userDescriptorAvailable,
+                byte frequencyBands)
         {
-            this.ComplexDescriptorAvailable = complexDescriptorAvailable;
-            this.IsuserDescriptorAvailable = userDescriptorAvailable;
-            this.ManufacturerCode = manufacturerCode;
-            this.BufferSize = bufferSize;
-            this.IncomingTransferSize = transferSize;
+            ComplexDescriptorAvailable = complexDescriptorAvailable;
+            IsuserDescriptorAvailable = userDescriptorAvailable;
+            ManufacturerCode = manufacturerCode;
+            BufferSize = bufferSize;
+            IncomingTransferSize = transferSize;
             SetLogicalType(logicalType);
             SetMacCapabilities(macCapabilities);
             SetFrequencyBands(frequencyBands);
             SetServerCapabilities(serverMask);
 
-            this._apsFlags = apsFlags;
+            _apsFlags = apsFlags;
         }
 
 
-        private void SetMacCapabilities(int macCapabilities)
+        private void SetMacCapabilities(byte macCapabilities)
         {
-            this.MacCapabilities.Clear();
-            if ((macCapabilities & 0x01) != 0)
-            {
-                this.MacCapabilities.Add(MacCapabilitiesType.ALTERNATIVE_PAN);
-            }
-            if ((macCapabilities & 0x02) != 0)
-            {
-                this.MacCapabilities.Add(MacCapabilitiesType.FULL_FUNCTION_DEVICE);
-            }
-            else
-            {
-                this.MacCapabilities.Add(MacCapabilitiesType.REDUCED_FUNCTION_DEVICE);
-            }
-            if ((macCapabilities & 0x04) != 0)
-            {
-                this.MacCapabilities.Add(MacCapabilitiesType.MAINS_POWER);
-            }
-            if ((macCapabilities & 0x08) != 0)
-            {
-                this.MacCapabilities.Add(MacCapabilitiesType.RECEIVER_ON_WHEN_IDLE);
-            }
-            if ((macCapabilities & 0x40) != 0)
-            {
-                this.MacCapabilities.Add(MacCapabilitiesType.SECURITY_CAPABLE);
-            }
+            MacCapabilities = (MacCapabilitiesType)(macCapabilities & 0x4f);
         }
 
-        private void SetLogicalType(int logicalType)
+        private void SetLogicalType(byte logicalType)
         {
-            switch (logicalType)
-            {
-                case 0:
-                    this.LogicalNodeType = LogicalType.COORDINATOR;
-                    break;
-                case 1:
-                    this.LogicalNodeType = LogicalType.ROUTER;
-                    break;
-                case 2:
-                    this.LogicalNodeType = LogicalType.END_DEVICE;
-                    break;
-                default:
-                    this.LogicalNodeType = LogicalType.UNKNOWN;
-                    break;
-            }
+            LogicalNodeType = logicalType<=2 ? (LogicalType)logicalType : LogicalType.UNKNOWN;
         }
 
         private void SetServerCapabilities(short serverMask)
         {
-            this.ServerCapabilities.Clear();
-            if ((serverMask & 0x01) != 0)
-            {
-                this.ServerCapabilities.Add(ServerCapabilitiesType.PRIMARY_TRUST_CENTER);
-            }
-            if ((serverMask & 0x02) != 0)
-            {
-                this.ServerCapabilities.Add(ServerCapabilitiesType.BACKUP_TRUST_CENTER);
-            }
-            if ((serverMask & 0x04) != 0)
-            {
-                this.ServerCapabilities.Add(ServerCapabilitiesType.PRIMARY_BINDING_TABLE_CACHE);
-            }
-            if ((serverMask & 0x08) != 0)
-            {
-                this.ServerCapabilities.Add(ServerCapabilitiesType.BACKUP_BINDING_TABLE_CACHE);
-            }
-            if ((serverMask & 0x10) != 0)
-            {
-                this.ServerCapabilities.Add(ServerCapabilitiesType.PRIMARY_DISCOVERY_CACHE);
-            }
-            if ((serverMask & 0x20) != 0)
-            {
-                this.ServerCapabilities.Add(ServerCapabilitiesType.BACKUP_DISCOVERY_CACHE);
-            }
-            if ((serverMask & 0x40) != 0)
-            {
-                this.ServerCapabilities.Add(ServerCapabilitiesType.NETWORK_MANAGER);
-            }
-
+            ServerCapabilities = (ServerCapabilitiesType)(serverMask & 0x00FF);
             StackCompliance = (serverMask & R21_BITMASK) >> R21_BITSHIFT;
         }
 
-        private void SetFrequencyBands(int frequencyBands)
+        private void SetFrequencyBands(byte frequencyBands)
         {
-            this.FrequencyBands.Clear();
-            if ((frequencyBands & 0x01) != 0)
-            {
-                this.FrequencyBands.Add(FrequencyBandType.FREQ_868_MHZ);
-            }
-            if ((frequencyBands & 0x04) != 0)
-            {
-                this.FrequencyBands.Add(FrequencyBandType.FREQ_902_MHZ);
-            }
-            if ((frequencyBands & 0x08) != 0)
-            {
-                this.FrequencyBands.Add(FrequencyBandType.FREQ_2400_MHZ);
-            }
+            FrequencyBands = (FrequencyBandType)(frequencyBands & 0x0f);
         }
 
         /// <summary>
@@ -229,11 +151,11 @@ namespace ZigBeeNet.ZDO.Field
             byte value2 = deserializer.ReadZigBeeType<byte>(DataType.DATA_8_BIT);
             byte value3 = deserializer.ReadZigBeeType<byte>(DataType.DATA_8_BIT);
 
-            SetLogicalType(value1 & 0x07);
+            SetLogicalType((byte)(value1 & 0x07));
             ComplexDescriptorAvailable = (value1 & 0x08) != 0;
             IsuserDescriptorAvailable = (value1 & 0x10) != 0;
 
-            SetFrequencyBands((value2 & 0xf8) >> 3);
+            SetFrequencyBands((byte)((value2 & 0xf8) >> 3));
             SetMacCapabilities(value3);
 
             // complexDescriptorAvailable = (Boolean) deserializer.deserialize(ZclDataType.BOOLEAN);
@@ -252,20 +174,20 @@ namespace ZigBeeNet.ZDO.Field
 
         public override int GetHashCode()
         {
-            int prime = 31;
+            const int prime = 31;
             int result = 1;
             result = prime * result + _apsFlags;
             result = prime * result + BufferSize;
             result = prime * result + (ComplexDescriptorAvailable ? 1231 : 1237);
             result = prime * result + (IsextendedEndpointListAvailable ? 1231 : 1237);
             result = prime * result + (ExtendedSimpleDescriptorListAvailable ? 1231 : 1237);
-            result = prime * result + ((FrequencyBands == null) ? 0 : FrequencyBands.GetHashCode());
+            result = prime * result + FrequencyBands.GetHashCode();
             result = prime * result + IncomingTransferSize;
             result = prime * result + LogicalNodeType.GetHashCode();
-            result = prime * result + ((MacCapabilities == null) ? 0 : MacCapabilities.GetHashCode());
+            result = prime * result + MacCapabilities.GetHashCode();
             result = prime * result + ManufacturerCode;
             result = prime * result + OutgoingTransferSize;
-            result = prime * result + ((ServerCapabilities == null) ? 0 : ServerCapabilities.GetHashCode());
+            result = prime * result + ServerCapabilities.GetHashCode();
             result = prime * result + (IsuserDescriptorAvailable ? 1231 : 1237);
             return result;
         }
@@ -273,92 +195,23 @@ namespace ZigBeeNet.ZDO.Field
         public override bool Equals(Object obj)
         {
             if (this == obj)
-            {
                 return true;
-            }
-            if (obj == null)
-            {
+            if (obj is null)
                 return false;
-            }
-            if (this.GetType() != obj.GetType())
-            {
-                return false;
-            }
-            NodeDescriptor other = (NodeDescriptor)obj;
-            if (_apsFlags != other._apsFlags)
-            {
-                return false;
-            }
-            if (BufferSize != other.BufferSize)
-            {
-                return false;
-            }
-            if (ComplexDescriptorAvailable != other.ComplexDescriptorAvailable)
-            {
-                return false;
-            }
-            if (IsextendedEndpointListAvailable != other.IsextendedEndpointListAvailable)
-            {
-                return false;
-            }
-            if (ExtendedSimpleDescriptorListAvailable != other.ExtendedSimpleDescriptorListAvailable)
-            {
-                return false;
-            }
-            if (FrequencyBands == null)
-            {
-                if (other.FrequencyBands != null)
-                {
-                    return false;
-                }
-            }
-            else if (!FrequencyBands.Equals(other.FrequencyBands)) // TODO: SequenceEquals ??
-            {
-                return false;
-            }
-            if (IncomingTransferSize != other.IncomingTransferSize)
-            {
-                return false;
-            }
-            if (LogicalNodeType != other.LogicalNodeType)
-            {
-                return false;
-            }
-            if (MacCapabilities == null)
-            {
-                if (other.MacCapabilities != null)
-                {
-                    return false;
-                }
-            }
-            else if (!MacCapabilities.Equals(other.MacCapabilities)) // TODO: SequenceEquals ??
-            {
-                return false;
-            }
-            if (ManufacturerCode != other.ManufacturerCode)
-            {
-                return false;
-            }
-            if (OutgoingTransferSize != other.OutgoingTransferSize)
-            {
-                return false;
-            }
-            if (ServerCapabilities == null)
-            {
-                if (other.ServerCapabilities != null)
-                {
-                    return false;
-                }
-            }
-            else if (!ServerCapabilities.Equals(other.ServerCapabilities)) // TODO: SequenceEquals ??
-            {
-                return false;
-            }
-            if (IsuserDescriptorAvailable != other.IsuserDescriptorAvailable)
-            {
-                return false;
-            }
-            return true;
+            return (obj is NodeDescriptor other) && 
+                    (_apsFlags == other._apsFlags) &&
+                    (BufferSize == other.BufferSize) &&
+                    (ComplexDescriptorAvailable == other.ComplexDescriptorAvailable) &&
+                    (IsextendedEndpointListAvailable == other.IsextendedEndpointListAvailable) &&
+                    (ExtendedSimpleDescriptorListAvailable == other.ExtendedSimpleDescriptorListAvailable) &&
+                    (FrequencyBands == other.FrequencyBands) &&
+                    (IncomingTransferSize == other.IncomingTransferSize) &&
+                    (LogicalNodeType == other.LogicalNodeType) &&
+                    (MacCapabilities == other.MacCapabilities ) &&
+                    (ManufacturerCode == other.ManufacturerCode) &&
+                    (OutgoingTransferSize == other.OutgoingTransferSize) &&
+                    (ServerCapabilities == other.ServerCapabilities) &&
+                    (IsuserDescriptorAvailable == other.IsuserDescriptorAvailable);
         }
 
 
@@ -366,10 +219,10 @@ namespace ZigBeeNet.ZDO.Field
         {
             return "NodeDescriptor [apsFlags=" + _apsFlags + ", bufferSize=" + BufferSize + ", complexDescriptorAvailable="
                     + ComplexDescriptorAvailable + ", manufacturerCode=" + ManufacturerCode + ", logicalType=" + LogicalNodeType
-                    + ", serverCapabilities=" + string.Join(", ", ServerCapabilities) + ", incomingTransferSize=" + IncomingTransferSize
+                    + ", serverCapabilities=" + ServerCapabilities.ToString() + ", incomingTransferSize=" + IncomingTransferSize
                     + ", outgoingTransferSize=" + OutgoingTransferSize + ", userDescriptorAvailable="
-                    + IsuserDescriptorAvailable + ", frequencyBands=" + string.Join(", ", FrequencyBands) + ", macCapabilities="
-                    + string.Join(", ", MacCapabilities) + ", extendedEndpointListAvailable=" + IsextendedEndpointListAvailable
+                    + IsuserDescriptorAvailable + ", frequencyBands=" + FrequencyBands.ToString() + ", macCapabilities="
+                    + MacCapabilities.ToString() + ", extendedEndpointListAvailable=" + IsextendedEndpointListAvailable
                     + ", extendedSimpleDescriptorListAvailable=" + ExtendedSimpleDescriptorListAvailable
                     + ", stackCompliance=" + StackCompliance + "]";
         }

--- a/libraries/ZigBeeNet/ZigBeeBroadcastDestination.cs
+++ b/libraries/ZigBeeNet/ZigBeeBroadcastDestination.cs
@@ -16,7 +16,7 @@ namespace ZigBeeNet
     /// parameter to FALSE. All other flags of the TxOptions parameter shall be set based
     /// on the network configuration
     /// </summary>
-    public enum BroadcastDestination : ushort
+    public enum ZigBeeBroadcastDestination : ushort
     {
         /// <summary>
         /// All devices in PAN
@@ -45,67 +45,9 @@ namespace ZigBeeNet
         BROADCAST_RESERVED_FFF8 = 0xFFF8,
     }
 
-
-    public class ZigBeeBroadcastDestination
+    public static class ZigBeeBroadcastDestinationHelper
     {
-        /// <summary>
-        /// A mapping between the integer code and its corresponding type to
-        /// facilitate lookup by code.
-        /// </summary>
-        private static Dictionary<BroadcastDestination, ZigBeeBroadcastDestination> _codeMapping;
-
-        public ushort Key { get; private set; }
-
-        public BroadcastDestination Destination { get; private set; }
-
-        private ZigBeeBroadcastDestination(BroadcastDestination destination)
-        {
-            this.Key = (ushort)destination;
-            this.Destination = destination;
-        }
-
-        private static void InitMapping()
-        {
-            _codeMapping = new Dictionary<BroadcastDestination, ZigBeeBroadcastDestination>
-            {
-                { BroadcastDestination.BROADCAST_ALL_DEVICES,  new ZigBeeBroadcastDestination(BroadcastDestination.BROADCAST_ALL_DEVICES) },
-                { BroadcastDestination.BROADCAST_RX_ON,  new ZigBeeBroadcastDestination(BroadcastDestination.BROADCAST_RX_ON) },
-                { BroadcastDestination.BROADCAST_ROUTERS_AND_COORD,  new ZigBeeBroadcastDestination(BroadcastDestination.BROADCAST_ROUTERS_AND_COORD) },
-                { BroadcastDestination.BROADCAST_LOW_POWER_ROUTERS,  new ZigBeeBroadcastDestination(BroadcastDestination.BROADCAST_LOW_POWER_ROUTERS) },
-                { BroadcastDestination.BROADCAST_RESERVED_FFFE,  new ZigBeeBroadcastDestination(BroadcastDestination.BROADCAST_RESERVED_FFFE) },
-                { BroadcastDestination.BROADCAST_RESERVED_FFFA,  new ZigBeeBroadcastDestination(BroadcastDestination.BROADCAST_RESERVED_FFFA) },
-                { BroadcastDestination.BROADCAST_RESERVED_FFF9,  new ZigBeeBroadcastDestination(BroadcastDestination.BROADCAST_RESERVED_FFF9) },
-                { BroadcastDestination.BROADCAST_RESERVED_FFF8,  new ZigBeeBroadcastDestination(BroadcastDestination.BROADCAST_RESERVED_FFF8) },
-            };
-        }
-
-        /// <summary>
-        /// Lookup function based on the EmberApsOption type code. Returns null
-        /// if the code does not exist.
-        /// </summary>
-        public static ZigBeeBroadcastDestination GetBroadcastDestination(ushort key)
-        {
-            if (_codeMapping == null)
-            {
-                InitMapping();
-            }
-
-            var i = (BroadcastDestination)key;
-
-            if (_codeMapping.ContainsKey(i))
-                return _codeMapping[i];
-            else
-                return null;
-        }
-
-        public static ZigBeeBroadcastDestination GetBroadcastDestination(BroadcastDestination dest)
-        {
-            return GetBroadcastDestination((ushort)dest);
-        }
-
-        public static bool IsBroadcast(int address)
-        {
-            return (address >= (ushort)BroadcastDestination.BROADCAST_RESERVED_FFF8 && address <= (ushort)BroadcastDestination.BROADCAST_ALL_DEVICES);
-        }
+        public static bool IsBroadcast(this ZigBeeBroadcastDestination address) => IsBroadcast((ushort)address);
+        public static bool IsBroadcast(ushort address) => (address >= (ushort)ZigBeeBroadcastDestination.BROADCAST_RESERVED_FFF8 && address <= (ushort)ZigBeeBroadcastDestination.BROADCAST_ALL_DEVICES);
     }
 }

--- a/libraries/ZigBeeNet/ZigBeeGroupAddress.cs
+++ b/libraries/ZigBeeNet/ZigBeeGroupAddress.cs
@@ -4,37 +4,22 @@ using System.Text;
 
 namespace ZigBeeNet
 {
-    public class ZigBeeGroupAddress : IZigBeeAddress, IComparable<IZigBeeAddress>
+    public struct ZigBeeGroupAddress : IZigBeeAddress, IComparable<ZigBeeGroupAddress>
     {
 
         /// <summary>
          /// The group ID.
          /// </summary>
-        public ushort GroupId
-        {
-            get
-            {
-                return Address;
-            }
-            set
-            {
-                Address = value;
-            }
-        }
+        public ushort GroupId => Address;
 
-        public ushort Address { get; set; }
+        public ushort Address { get; }
 
-        /// <summary>
-         /// The group label.
-         /// </summary>
-        private string Label { get; set; }
-
-        /// <summary>
-         /// Default constructor.
-         /// </summary>
-        public ZigBeeGroupAddress()
-        {
-        }
+        // /// <summary>
+        //  /// Default constructor.
+        //  /// </summary>
+        // public ZigBeeGroupAddress()
+        // {
+        // }
 
         /// <summary>
          /// Constructor which sets group ID.
@@ -44,47 +29,13 @@ namespace ZigBeeNet
          /// </summary>
         public ZigBeeGroupAddress(ushort groupId)
         {
-            GroupId = groupId;
+            Address = groupId;
         }
 
-        /// <summary>
-         /// Constructor which sets group ID and label.
-         ///
-         /// @param groupId
-         ///            the group ID
-         /// @param label
-         ///            the group label
-         /// </summary>
-        public ZigBeeGroupAddress(ushort groupId, string label)
-        {
-            GroupId = groupId;
-            Label = label;
-        }
 
-        public bool IsGroup
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public bool IsGroup => true;
 
-        public int CompareTo(IZigBeeAddress other)
-        {
-            if (this == other)
-            {
-                return 0;
-            }
-
-            ZigBeeGroupAddress thatAddr = (ZigBeeGroupAddress)other;
-
-            if (thatAddr.GroupId == GroupId)
-            {
-                return 0;
-            }
-
-            return (thatAddr.GroupId < GroupId) ? -1 : 1;
-        }
+        public int CompareTo(ZigBeeGroupAddress other)  => (int)Address - (int)other.Address;
 
         public static bool operator >(ZigBeeGroupAddress operand1, ZigBeeGroupAddress operand2)
         {
@@ -111,19 +62,14 @@ namespace ZigBeeNet
 
         public override int GetHashCode()
         {
-            return GroupId.GetHashCode();
+            return Address;
         }
 
         public override bool Equals(object obj)
         {
-            if (obj == null)
-            {
-                return false;
-            }
-            if (obj is ZigBeeGroupAddress other)
-                return other.GroupId == GroupId;
-
-            return false;
+            return !(obj is null) && (obj is ZigBeeGroupAddress other) && CompareTo(other)==0;
         }
+
+
     }
 }

--- a/libraries/ZigBeeNet/ZigBeeNetworkManager.cs
+++ b/libraries/ZigBeeNet/ZigBeeNetworkManager.cs
@@ -1103,7 +1103,7 @@ namespace ZigBeeNet
         /// </summary>
         public ZigBeeStatus PermitJoin(byte duration)
         {
-            return PermitJoin(new ZigBeeEndpointAddress(ZigBeeBroadcastDestination.GetBroadcastDestination(BroadcastDestination.BROADCAST_ROUTERS_AND_COORD).Key), duration);
+            return PermitJoin(ZigBeeEndpointAddress.BROADCAST_ROUTERS_AND_COORD, duration);
         }
 
         /// <summary>
@@ -1131,21 +1131,21 @@ namespace ZigBeeNet
                 PermitDuration = duration,
                 TcSignificance = true,
                 DestinationAddress = destination,
-                SourceAddress = new ZigBeeEndpointAddress(0)
+                SourceAddress = ZigBeeEndpointAddress.Zero
             };
 
             SendCommand(command);
 
             // If this is a broadcast, then we send it to our own address as well
             // This seems to be required for some stacks (eg ZNP)
-            if (ZigBeeBroadcastDestination.GetBroadcastDestination(destination.Address) != null)
+            if (ZigBeeBroadcastDestinationHelper.IsBroadcast(destination.Address))
             {
                 command = new ManagementPermitJoiningRequest
                 {
                     PermitDuration = duration,
                     TcSignificance = true,
-                    DestinationAddress = new ZigBeeEndpointAddress(0),
-                    SourceAddress = new ZigBeeEndpointAddress(0)
+                    DestinationAddress = ZigBeeEndpointAddress.Zero,
+                    SourceAddress = ZigBeeEndpointAddress.Zero
                 };
 
                 SendCommand(command);
@@ -1180,7 +1180,7 @@ namespace ZigBeeNet
 
                 command.DeviceAddress = leaveAddress;
                 command.DestinationAddress = new ZigBeeEndpointAddress(destinationAddress);
-                command.SourceAddress = new ZigBeeEndpointAddress(0);
+                command.SourceAddress = ZigBeeEndpointAddress.Zero;
                 command.RemoveChildrenRejoin = false;
 
                 CommandResult response = await SendTransaction(command, command);

--- a/libraries/ZigBeeNet/ZigBeeNode.cs
+++ b/libraries/ZigBeeNet/ZigBeeNode.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -224,14 +224,8 @@ namespace ZigBeeNet
         ///
         /// <returns>true if the device is a Full Function Device. Returns false if not an FFD or logical type is unknown.</returns>
         /// </summary>
-        public bool IsFullFunctionDevice()
-        {
-            if (NodeDescriptor == null)
-            {
-                return false;
-            }
-            return NodeDescriptor.MacCapabilities.Contains(MacCapabilitiesType.FULL_FUNCTION_DEVICE);
-        }
+        public bool IsFullFunctionDevice => 
+            (NodeDescriptor?.MacCapabilities & MacCapabilitiesType.FULL_FUNCTION_DEVICE)==MacCapabilitiesType.FULL_FUNCTION_DEVICE;
 
         /// <summary>
         /// Returns true if the node is a Reduced Function Device. Returns false if not an RFD or logical type is unknown.
@@ -243,41 +237,11 @@ namespace ZigBeeNet
         ///
         /// <returns>true if the device is a Reduced Function Device</returns>
         /// </summary>
-        public bool IsReducedFuntionDevice
-        {
-            get
-            {
-                if (NodeDescriptor == null)
-                {
-                    return false;
-                }
-                return NodeDescriptor.MacCapabilities.Contains(MacCapabilitiesType.REDUCED_FUNCTION_DEVICE);
-            }
-        }
+        public bool IsReducedFuntionDevice => !(NodeDescriptor is null) && !IsFullFunctionDevice;
 
-        public bool IsSecurityCapable
-        {
-            get
-            {
-                if (NodeDescriptor == null)
-                {
-                    return false;
-                }
-                return NodeDescriptor.MacCapabilities.Contains(MacCapabilitiesType.SECURITY_CAPABLE);
-            }
-        }
+        public bool IsSecurityCapable => (NodeDescriptor?.MacCapabilities & MacCapabilitiesType.SECURITY_CAPABLE) == MacCapabilitiesType.SECURITY_CAPABLE;
 
-        public bool IsPrimaryTrustCenter
-        {
-            get
-            {
-                if (NodeDescriptor == null)
-                {
-                    return false;
-                }
-                return NodeDescriptor.ServerCapabilities.Contains(ServerCapabilitiesType.PRIMARY_TRUST_CENTER);
-            }
-        }
+        public bool IsPrimaryTrustCenter => (NodeDescriptor?.ServerCapabilities & ServerCapabilitiesType.PRIMARY_TRUST_CENTER) == ServerCapabilitiesType.PRIMARY_TRUST_CENTER;
 
         /// <summary>
         /// Gets the <see cref="LogicalType"> of the node.

--- a/libraries/ZigBeeNet/ZigBeeNode.cs
+++ b/libraries/ZigBeeNet/ZigBeeNode.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -189,8 +189,8 @@ namespace ZigBeeNet
             }
 
             command.TcSignificance = true;
-            command.DestinationAddress = new ZigBeeEndpointAddress(0);
-            command.SourceAddress = new ZigBeeEndpointAddress(0);
+            command.DestinationAddress = ZigBeeEndpointAddress.Zero;
+            command.SourceAddress = ZigBeeEndpointAddress.Zero;
 
             _network.SendTransaction(command);
         }

--- a/libraries/ZigbeeNet.Hardware.Ember/Internal/Serializer/EzspSerializer.cs
+++ b/libraries/ZigbeeNet.Hardware.Ember/Internal/Serializer/EzspSerializer.cs
@@ -105,14 +105,15 @@ namespace ZigBeeNet.Hardware.Ember.Internal.Serializer
 
         public void SerializeEmberEui64(IeeeAddress address) 
         {
-            _buffer[_length++] = address.GetAddress()[0];
-            _buffer[_length++] = address.GetAddress()[1];
-            _buffer[_length++] = address.GetAddress()[2];
-            _buffer[_length++] = address.GetAddress()[3];
-            _buffer[_length++] = address.GetAddress()[4];
-            _buffer[_length++] = address.GetAddress()[5];
-            _buffer[_length++] = address.GetAddress()[6];
-            _buffer[_length++] = address.GetAddress()[7];
+            var addr=address.GetAddress();
+            _buffer[_length++] = addr[0];
+            _buffer[_length++] = addr[1];
+            _buffer[_length++] = addr[2];
+            _buffer[_length++] = addr[3];
+            _buffer[_length++] = addr[4];
+            _buffer[_length++] = addr[5];
+            _buffer[_length++] = addr[6];
+            _buffer[_length++] = addr[7];
         }
 
         public void SerializeEmberNetworkParameters(EmberNetworkParameters networkParameters) 

--- a/libraries/ZigbeeNet.Hardware.Ember/ZigBeeDongleEzsp.cs
+++ b/libraries/ZigbeeNet.Hardware.Ember/ZigBeeDongleEzsp.cs
@@ -744,7 +744,7 @@ namespace ZigBeeNet.Hardware.Ember
             // Update the extendedTimeout flag in the address table.
             // Users should ensure the address table is large enough to hold all nodes on the network.
             _logger.LogDebug("{IeeeAddress}: NodeDescriptor passed to Ember NCP {NodeDescriptor}", ieeeAddress, nodeDescriptor);
-            if (!nodeDescriptor.MacCapabilities.Contains(NodeDescriptor.MacCapabilitiesType.RECEIVER_ON_WHEN_IDLE)) 
+            if ((nodeDescriptor.MacCapabilities&NodeDescriptor.MacCapabilitiesType.RECEIVER_ON_WHEN_IDLE)==0) 
             {
                 EmberNcp ncp = GetEmberNcp();
                 ncp.SetExtendedTimeout(ieeeAddress, true);

--- a/libraries/ZigbeeNet.Hardware.Ember/ZigBeeDongleEzsp.cs
+++ b/libraries/ZigbeeNet.Hardware.Ember/ZigBeeDongleEzsp.cs
@@ -631,7 +631,7 @@ namespace ZigBeeNet.Hardware.Ember
                 emberApsFrame.AddOptions(EmberApsOption.EMBER_APS_OPTION_ENCRYPTION);
             }
 
-            if (apsFrame.AddressMode == ZigBeeNwkAddressMode.Device && !ZigBeeBroadcastDestination.IsBroadcast(apsFrame.DestinationAddress)) 
+            if (apsFrame.AddressMode == ZigBeeNwkAddressMode.Device && !ZigBeeBroadcastDestinationHelper.IsBroadcast(apsFrame.DestinationAddress)) 
             {
                 EzspSendUnicastRequest emberUnicast = new EzspSendUnicastRequest();
                 emberUnicast.SetIndexOrDestination(apsFrame.DestinationAddress);
@@ -659,7 +659,7 @@ namespace ZigBeeNet.Hardware.Ember
 
                 transaction = new EzspSingleResponseTransaction(emberUnicast, typeof(EzspSendUnicastResponse));
             } 
-            else if (apsFrame.AddressMode == ZigBeeNwkAddressMode.Device && ZigBeeBroadcastDestination.IsBroadcast(apsFrame.DestinationAddress)) 
+            else if (apsFrame.AddressMode == ZigBeeNwkAddressMode.Device && ZigBeeBroadcastDestinationHelper.IsBroadcast(apsFrame.DestinationAddress)) 
             {
                 EzspSendBroadcastRequest emberBroadcast = new EzspSendBroadcastRequest();
                 emberBroadcast.SetDestination(apsFrame.DestinationAddress);

--- a/samples/ZigBeeNet.PlayGround/Program.cs
+++ b/samples/ZigBeeNet.PlayGround/Program.cs
@@ -376,21 +376,13 @@ namespace ZigBeeNet.PlayGround
 
                             if (node != null)
                             {
-                                ZigBeeEndpointAddress endpointAddress = null;
                                 var endpoint = node.GetEndpoints().FirstOrDefault();
-
-                                if (endpoint != null)
-                                {
-                                    endpointAddress = endpoint.GetEndpointAddress();
-                                }
-
-                                if (endpointAddress == null)
+                                if (endpoint is null)
                                 {
                                     Console.WriteLine("No endpoint found");
-
                                     continue;
                                 }
-
+                                ZigBeeEndpointAddress endpointAddress = endpoint.GetEndpointAddress();
                                 try
                                 {
                                     if (cmd == "leave")

--- a/test/ZigBeeNet.Hardware.Digi.XBee.Test/Internal/Protocol/XBeeCreateSourceRouteCommandTest.cs
+++ b/test/ZigBeeNet.Hardware.Digi.XBee.Test/Internal/Protocol/XBeeCreateSourceRouteCommandTest.cs
@@ -21,7 +21,7 @@ namespace ZigBeeNet.Hardware.Digi.XBee.Test.Internal.Protocol
             XBeeCreateSourceRouteCommand command = new XBeeCreateSourceRouteCommand();
 
             command.SetFrameId(0);
-            command.SetIeeeAddress(new IeeeAddress(BigInteger.Parse("0013A20040401122", System.Globalization.NumberStyles.HexNumber)));
+            command.SetIeeeAddress(new IeeeAddress(0x0013A20040401122ul));
             
             command.SetNetworkAddress(0x3344);
             command.SetAddressList(new int[] { 0xEEFF, 0xCCDD, 0xAABB });

--- a/test/ZigBeeNet.Hardware.Digi.XBee.Test/Internal/Protocol/XBeeReceivePacketEventTest.cs
+++ b/test/ZigBeeNet.Hardware.Digi.XBee.Test/Internal/Protocol/XBeeReceivePacketEventTest.cs
@@ -25,7 +25,7 @@ namespace ZigBeeNet.Hardware.Digi.XBee.Test.Internal.Protocol
             Assert.Equal(0x90, responseEvent.GetFrameType());
             Assert.Equal(0x7D84, responseEvent.GetNetworkAddress());
             Assert.Equal(ReceiveOptions.PACKET_ACKNOWLEDGED, responseEvent.GetReceiveOptions());
-            Assert.Equal(new IeeeAddress(BigInteger.Parse("0013A20040522BAA", System.Globalization.NumberStyles.HexNumber)), responseEvent.GetIeeeAddress());
+            Assert.Equal(new IeeeAddress(0x0013A20040522BAAul), responseEvent.GetIeeeAddress());
 
             int[] arrayToTestAgainst = GetPacketData("52 78 44 61 74 61");
             int[] getDataResult = responseEvent.GetData();

--- a/test/ZigBeeNet.Hardware.Digi.XBee.Test/Internal/Protocol/XBeeReceivePacketExplicitEventTest.cs
+++ b/test/ZigBeeNet.Hardware.Digi.XBee.Test/Internal/Protocol/XBeeReceivePacketExplicitEventTest.cs
@@ -29,7 +29,7 @@ namespace ZigBeeNet.Hardware.Digi.XBee.Test.Internal.Protocol
             Assert.Equal(0x2211, responseEvent.GetClusterId());
             Assert.Equal(0xC105, responseEvent.GetProfileId());
             Assert.Equal(ReceiveOptions.PACKET_BROADCAST, responseEvent.GetReceiveOptions());
-            Assert.Equal(new IeeeAddress(BigInteger.Parse("0013A20040522BAA", System.Globalization.NumberStyles.HexNumber)), responseEvent.GetIeeeAddress());
+            Assert.Equal(new IeeeAddress(0x0013A20040522BAAul), responseEvent.GetIeeeAddress());
             
             int[] arrayToTestAgainst = GetPacketData("52 78 44 61 74 61");
             int[] getDataResult = responseEvent.GetData();

--- a/test/ZigBeeNet.Hardware.Digi.XBee.Test/Internal/Protocol/XBeeRouteRecordEventTest.cs
+++ b/test/ZigBeeNet.Hardware.Digi.XBee.Test/Internal/Protocol/XBeeRouteRecordEventTest.cs
@@ -23,7 +23,7 @@ namespace ZigBeeNet.Hardware.Digi.XBee.Test.Internal.Protocol
             Assert.Equal(0xA1, responseEvent.GetFrameType());
             Assert.Equal(0x3344, responseEvent.GetNetworkAddress());
             Assert.Equal(ReceiveOptions.PACKET_ACKNOWLEDGED, responseEvent.GetReceiveOptions());
-            Assert.Equal(new IeeeAddress(BigInteger.Parse("0013A20040401122", System.Globalization.NumberStyles.HexNumber)), responseEvent.GetIeeeAddress());
+            Assert.Equal(new IeeeAddress(0x0013A20040401122ul), responseEvent.GetIeeeAddress());
             Assert.Equal(3, responseEvent.GetAddressList().Length);
         }
     }

--- a/test/ZigBeeNet.Hardware.Digi.XBee.Test/Internal/XBeeEventFactoryTest.cs
+++ b/test/ZigBeeNet.Hardware.Digi.XBee.Test/Internal/XBeeEventFactoryTest.cs
@@ -27,7 +27,7 @@ namespace ZigBeeNet.Hardware.Digi.XBee.Test
 
             XBeeOtaFirmwareUpdateStatusEvent xbeeEvent = (XBeeOtaFirmwareUpdateStatusEvent)frame;
             Assert.Equal(0, xbeeEvent.GetBlockNumber());
-            Assert.Equal(new IeeeAddress(BigInteger.Parse("0013A2004162F61A", System.Globalization.NumberStyles.HexNumber)), xbeeEvent.GetIeeeAddress());
+/*  */            Assert.Equal(new IeeeAddress(0x0013A2004162F61Aul), xbeeEvent.GetIeeeAddress());
             Assert.Equal(0, xbeeEvent.GetNetworkAddress());
         }
 

--- a/test/ZigBeeNet.Hardware.Digi.XBee.Test/ZigBeeDongleXBeeTest.cs
+++ b/test/ZigBeeNet.Hardware.Digi.XBee.Test/ZigBeeDongleXBeeTest.cs
@@ -67,7 +67,7 @@ namespace ZigBeeNet.Hardware.Digi.XBee.Test
             {
                 DestinationAddress = 46946,
                 DestinationEndpoint = 0,
-                DestinationIeeeAddress = new IeeeAddress(BigInteger.Parse("000D6F00057CF7C6", NumberStyles.HexNumber)),
+                DestinationIeeeAddress = new IeeeAddress(0x000D6F00057CF7C6ul),
                 Cluster = 32774,
                 AddressMode = ZigBeeNwkAddressMode.Device,
                 Radius = 31,

--- a/test/ZigBeeNet.Test/IeeeAddressTest.cs
+++ b/test/ZigBeeNet.Test/IeeeAddressTest.cs
@@ -8,9 +8,15 @@ namespace ZigBeeNet.Test
         [Fact]
         public void IsEqual()
         {
-            IeeeAddress address1 = new IeeeAddress("17880100dc880b");
+            // byte[] order is little endian
+            byte[] baAddress = new byte[] {0x0b,0x88,0xdc,0x00,0x01,0x88,0x17,0x00};
+            IeeeAddress address1 = new IeeeAddress(0x17880100dc880bul);
             IeeeAddress address2 = new IeeeAddress("17880100dc880b");
+            IeeeAddress address3 = new IeeeAddress(baAddress);
             Assert.True(address1.Equals(address2));
+            Assert.True(address1.Equals(address3));
+            Assert.Equal(address1.GetAddress(),baAddress);
         }
+
     }
 }

--- a/test/ZigBeeNet.Test/ZigBeeBroadcastDestinationTest.cs
+++ b/test/ZigBeeNet.Test/ZigBeeBroadcastDestinationTest.cs
@@ -10,13 +10,10 @@ namespace ZigBeeNet.Test
         [Fact]
     public void GetDestination()
         {
-            ZigBeeBroadcastDestination destination = ZigBeeBroadcastDestination.GetBroadcastDestination(0xFFFC);
-            Assert.Equal(BroadcastDestination.BROADCAST_ROUTERS_AND_COORD, destination.Destination);
+            Assert.Equal(0xFFFC, (ushort)ZigBeeBroadcastDestination.BROADCAST_ROUTERS_AND_COORD);
 
-            destination = ZigBeeBroadcastDestination.GetBroadcastDestination(0xFFFB);
-            Assert.Equal(BroadcastDestination.BROADCAST_LOW_POWER_ROUTERS, destination.Destination);
-
-            Assert.Equal(0xFFFF, (ushort)BroadcastDestination.BROADCAST_ALL_DEVICES);
+            Assert.Equal(0xFFFB,(ushort)ZigBeeBroadcastDestination.BROADCAST_LOW_POWER_ROUTERS);
+            Assert.Equal(0xFFFF, (ushort)ZigBeeBroadcastDestination.BROADCAST_ALL_DEVICES);
         }
     }
 }

--- a/test/ZigBeeNet.Test/ZigBeeEndpointAddressTest.cs
+++ b/test/ZigBeeNet.Test/ZigBeeEndpointAddressTest.cs
@@ -34,7 +34,7 @@ namespace ZigBeeNet.Test
         [Fact]
         public void TestStringConstructorError()
         {
-            Assert.Throws<FormatException>(() => new ZigBeeEndpointAddress(""));
+            Assert.Throws<ArgumentException>(() => new ZigBeeEndpointAddress(""));
             Assert.Throws<ArgumentException>(() => new ZigBeeEndpointAddress("111/22/33"));
         }
 


### PR DESCRIPTION
This PR introduces several changes:

- Simplify `NodeDescriptor` and `PowerDescriptor` to use directly `Enum [flags]` instead of `List<Enum>` for several fields
- Change `ZigBeeNode` accordingly
- Fix Json store : before the previous changes [des]serialization wasn't working as expected specially on non-public fields and list of enums
- Fix MongoDB store : before the previous changes [des]serialization wasn't working as expected on several fields, change also the serialization of `IeeeAddress` and index it
- Change `IZigBeeAddress`: define properties as readonly, refactor descendant classes
- Simplify `IeeeAddress` class

These changes are to some extends breaking changes for library consumers:
- some properties are changed from `List<Enum>` -> `Enum`
- the json and mongodb stores formats are slightly changed from previous version (but now seems functional)
- some objects are now immutable

